### PR TITLE
Add 32bit windows coreclr build and test yamato script

### DIFF
--- a/.yamato/build_and_test_linux_x64.yml
+++ b/.yamato/build_and_test_linux_x64.yml
@@ -2,7 +2,7 @@ name: Build and Test Linux x64
 
 agent:
   type: Unity::VM
-  image: platform-foundation/linux-ubuntu-18.04-mono-bokken:latest
+  image: platform-foundation/linux-ubuntu-18.04-mono-bokken:0.1.7-978398
   flavor: b1.large
 
 commands:

--- a/.yamato/build_windows.yml
+++ b/.yamato/build_windows.yml
@@ -1,0 +1,31 @@
+name: Build and Test Windows x86
+
+agent:
+  type: Unity::VM
+  image: platform-foundation/windows-vs2019-il2cpp-bokken:latest
+  flavor: b1.xlarge
+
+commands:
+  - |
+    cd unity\unitygc
+    cmake . -A Win32
+    cmake --build . --config Release
+  - build.cmd -subset clr+libs -a x86 -c release -ci
+  - copy unity\unitygc\Release\unitygc.dll artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86\native 
+  - powershell .yamato\scripts\download_7z.ps1
+  - artifacts\7za-win-x64\7za.exe a artifacts\unity\dotnet-runtime-unity-win-x86.7z .\artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86
+# build/run tests
+  - build.cmd libs.tests -test -a x86 -c release -ci
+  - src\tests\build.cmd x86 release ci
+  - src\tests\run.cmd x86 release
+
+triggers:
+  pull_requests:
+    - targets:
+        only:
+          - "unity-main"
+
+artifacts: 
+  win64:
+    paths:
+      - artifacts\unity\dotnet-runtime-unity-win-x86.7z

--- a/src/tests/readytorun/r2rdump/FrameworkTests/R2RDumpTests.csproj
+++ b/src/tests/readytorun/r2rdump/FrameworkTests/R2RDumpTests.csproj
@@ -4,6 +4,7 @@
     <!-- The test is lengthy as it scans the entire System.Private.CoreLib so that it times out in GC stress runs. -->
     <!-- The purpose of the test is functional testing of the R2R reader, not runtime stress testing. -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="R2RDumpTester.cs" />


### PR DESCRIPTION
Notes: I have an open issue upstream (https://github.com/dotnet/runtime/issues/65205) for an issue that was blocking me from reproducing this on the latest `main`.  I was however able to reproduce on rev f130138b337b57342e94dabf499b818531effed5 from upstream `main`. Once the larger issue is addressed I will attempt to repro the test failure that I've worked around in `src/tests/readytorun/r2rdump/FrameworkTests/R2RDumpTests.csproj` and open an issue if it's still there. 