### PR TITLE
Package host assembly into runtime artifact

### DIFF
--- a/.yamato/build_linux_x64.yml
+++ b/.yamato/build_linux_x64.yml
@@ -14,6 +14,7 @@ commands:
   - mkdir artifacts
   - curl https://public-stevedore.unity3d.com/r/public/7za-linux-x64/e6c75fb7ffda_e6a295cdcae3f74d315361883cf53f75141be2e739c020035f414a449d4876af.zip --output artifacts/7za-linux-x64.zip
   - unzip artifacts/7za-linux-x64.zip -d artifacts/7za-linux-x64
+  - ./dotnet.sh build unity/managed.sln -c Release
   - |
     cd unity/unitygc
     mkdir release
@@ -22,6 +23,8 @@ commands:
     cmake --build .
   - ./build.sh -subset clr+libs+libs -a x64 -c release -ci -ninja
   - cp unity/unitygc/release/libunitygc.so artifacts/bin/microsoft.netcore.app.runtime.linux-x64/Release/runtimes/linux-x64/native
+  - cp artifacts/bin/unity-embed-host/Release/net6.0/unity-embed-host.dll artifacts/bin/microsoft.netcore.app.runtime.linux-x64/Release/runtimes/linux-x64/lib/net7.0
+  - cp artifacts/bin/unity-embed-host/Release/net6.0/unity-embed-host.dll artifacts/bin/microsoft.netcore.app.runtime.linux-x64/Release/runtimes/linux-x64/lib/net7.0
   - artifacts/7za-linux-x64/7za a artifacts/unity/$ARTIFACT_FILENAME ./artifacts/bin/microsoft.netcore.app.runtime.linux-x64/Release/runtimes/linux-x64/*
 
 artifacts:

--- a/.yamato/build_osx_arm64.yml
+++ b/.yamato/build_osx_arm64.yml
@@ -14,6 +14,7 @@ commands:
   - mkdir artifacts
   - curl https://public-stevedore.unity3d.com/r/public/7za-mac-x64/e6c75fb7ffda_5bd76652986a0e3756d1cfd7e84ce056a9e1dbfc5f70f0514a001f724c0fbad2.zip --output artifacts/7za-mac-x64.zip
   - unzip artifacts/7za-mac-x64.zip -d artifacts/7za-mac-x64
+  - ./dotnet.sh build unity/managed.sln -c Release
   - |
     cd unity/unitygc
     mkdir release
@@ -22,6 +23,8 @@ commands:
     cmake --build .
   - LD_LIBRARY_PATH=/usr/local/opt/openssl/lib ./build.sh -subset clr+libs -a arm64 -c release -cross -ci -ninja /p:CrossBuild=true
   - cp unity/unitygc/release/libunitygc.dylib artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Release/runtimes/osx-arm64/native
+  - cp artifacts/bin/unity-embed-host/Release/net6.0/unity-embed-host.dll artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Release/runtimes/osx-arm64/lib/net7.0
+  - cp artifacts/bin/unity-embed-host/Release/net6.0/unity-embed-host.pdb artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Release/runtimes/osx-arm64/lib/net7.0
   - artifacts/7za-mac-x64/7za a artifacts/unity/$ARTIFACT_FILENAME ./artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Release/runtimes/osx-arm64/*
 
 artifacts:

--- a/.yamato/build_osx_x64.yml
+++ b/.yamato/build_osx_x64.yml
@@ -14,6 +14,7 @@ commands:
   - mkdir artifacts
   - curl https://public-stevedore.unity3d.com/r/public/7za-mac-x64/e6c75fb7ffda_5bd76652986a0e3756d1cfd7e84ce056a9e1dbfc5f70f0514a001f724c0fbad2.zip --output artifacts/7za-mac-x64.zip
   - unzip artifacts/7za-mac-x64.zip -d artifacts/7za-mac-x64
+  - ./dotnet.sh build unity/managed.sln -c Release
   - |
     cd unity/unitygc
     mkdir release
@@ -22,6 +23,8 @@ commands:
     cmake --build .
   - LD_LIBRARY_PATH=/usr/local/opt/openssl/lib ./build.sh -subset clr+libs -a x64 -c release -ci -ninja
   - cp unity/unitygc/release/libunitygc.dylib artifacts/bin/microsoft.netcore.app.runtime.osx-x64/Release/runtimes/osx-x64/native
+  - cp artifacts/bin/unity-embed-host/Release/net6.0/unity-embed-host.dll artifacts/bin/microsoft.netcore.app.runtime.osx-x64/Release/runtimes/osx-x64/lib/net7.0
+  - cp artifacts/bin/unity-embed-host/Release/net6.0/unity-embed-host.pdb artifacts/bin/microsoft.netcore.app.runtime.osx-x64/Release/runtimes/osx-x64/lib/net7.0
   - artifacts/7za-mac-x64/7za a artifacts/unity/$ARTIFACT_FILENAME ./artifacts/bin/microsoft.netcore.app.runtime.osx-x64/Release/runtimes/osx-x64/*
 
 artifacts:

--- a/.yamato/build_windows.yml
+++ b/.yamato/build_windows.yml
@@ -11,12 +11,15 @@ variables:
   ARTIFACT_FILENAME: {{globals.artifact_base_name}}-win-x86.7z
 
 commands:
+  - dotnet build unity\managed.sln -c Release
   - |
     cd unity\unitygc
     cmake . -A Win32
     cmake --build . --config Release
   - build.cmd -subset clr+libs -a x86 -c release -ci
-  - copy unity\unitygc\Release\unitygc.dll artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86\native 
+  - copy unity\unitygc\Release\unitygc.dll artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86\native
+  - copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.dll artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86\lib\net7.0
+  - copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.pdb artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86\lib\net7.0
   - powershell .yamato\scripts\download_7z.ps1
   - artifacts\7za-win-x64\7za.exe a artifacts\unity\%ARTIFACT_FILENAME% .\artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86\*
 

--- a/.yamato/build_windows_x64.yml
+++ b/.yamato/build_windows_x64.yml
@@ -11,12 +11,15 @@ variables:
   ARTIFACT_FILENAME: {{globals.artifact_base_name}}-win-x64.7z
 
 commands:
+  - dotnet build unity\managed.sln -c Release
   - |
     cd unity\unitygc
     cmake .
     cmake --build . --config Release
   - build.cmd -subset clr+libs -a x64 -c release -ci
-  - copy unity\unitygc\Release\unitygc.dll artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\native 
+  - copy unity\unitygc\Release\unitygc.dll artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\native
+  - copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.dll artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\lib\net7.0 
+  - copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.pdb artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\lib\net7.0 
   - powershell .yamato\scripts\download_7z.ps1
   - artifacts\7za-win-x64\7za.exe a artifacts\unity\%ARTIFACT_FILENAME% .\artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\*
 


### PR DESCRIPTION
Avoid an extra artifact as the runtimes need this to function in Unity anyway.

This will require changes to the Unity integration once this lands.