### PR TITLE
Fix mono_string_new_len() to allocate the correct number of bytes when a unicode string has been passed in.

### DIFF
--- a/src/coreclr/vm/mono/MonoCoreClr.h
+++ b/src/coreclr/vm/mono/MonoCoreClr.h
@@ -35,6 +35,7 @@ typedef void* mono_liveness_world_state_callback;
 // TODO: Move this to CMake
 #define ENABLE_MONO 1
 #define CORECLR 1
+#define ENABLE_CORECLR 1
 
 #if defined(_DEBUG)
 #define MONO_PRE_ASSERTE         /* if you need to change modes before doing asserts override */

--- a/src/coreclr/vm/mono/mono_coreclr.cpp
+++ b/src/coreclr/vm/mono/mono_coreclr.cpp
@@ -3025,7 +3025,7 @@ extern "C" EXPORT_API MonoString* EXPORT_CC mono_string_new_len(MonoDomain *doma
     assert(text != nullptr);
     InlineSString<256> sstr(SString::Utf8, text, length);
     GCX_COOP();
-    STRINGREF strObj = AllocateString(length);
+    STRINGREF strObj = AllocateString(sstr.GetCount());
     memcpyNoGCRefs(strObj->GetBuffer(), sstr.GetUnicode(), sstr.GetCount() * sizeof(WCHAR));
     return (MonoString*)OBJECTREFToObject(strObj);
 }

--- a/unity/embed_api_tests/main.cpp
+++ b/unity/embed_api_tests/main.cpp
@@ -1692,6 +1692,7 @@ TEST(mono_custom_attrs_has_attr_can_check_assembly_attribute)
 #define kHelloString "Hello"
 #define kHelloWorldString "Hello, World!"
 #define kHelloWorldStringWithEmbeddedNull "Hello\0World"
+#define kHelloWorldStringWithUnicode "Hello, 団結!"
 
 void CheckString(MonoString* str, const char* expected, size_t len)
 {
@@ -1722,6 +1723,15 @@ TEST(mono_string_new_len_creates_string)
     CheckString(mono_string_new_len(mono_domain_get(), kHelloWorldString, 13), kHelloWorldString, 13);
     CheckString(mono_string_new_len(mono_domain_get(), kHelloWorldString, 5), kHelloString, 5);
     CheckString(mono_string_new_len(mono_domain_get(), kHelloWorldStringWithEmbeddedNull, 11), kHelloWorldStringWithEmbeddedNull, 11);
+}
+
+TEST(mono_string_new_len_with_unicode_ascii_creates_string)
+{
+    if (g_Mode == CoreCLR)
+    {
+        MonoString* str = mono_string_new_len(mono_domain_get(), kHelloWorldStringWithUnicode, strlen(kHelloWorldStringWithUnicode));
+        CHECK(str->length == 10);
+    }
 }
 
 void *ThreadFunc(void *arguments)

--- a/unity/unity-sources/Runtime/Mono/MonoFunctions.h
+++ b/unity/unity-sources/Runtime/Mono/MonoFunctions.h
@@ -515,18 +515,6 @@ typedef UNUSED_SYMBOL void (*UnityLogErrorCallback) (const char* message);
 DO_API(void, mono_unity_set_editor_logging_callback, (UnityLogErrorCallback callback))
 #endif
 
-#if ENABLE_CORECLR
-DO_API(int, coreclr_array_length, (MonoArray * array))
-DO_API(void, mono_gc_mark_stack_slot, (void* objRef))
-DO_API(void, mono_gc_unmark_stack_slot, (void* objRef))
-DO_API(MonoObject*, mono_runtime_invoke_with_nested_object, (MonoMethod * method, void *obj, void *parentobj, void **params, MonoException **exc));
-DO_API(int, mono_type_get_num_generic_args, (MonoType * type))
-DO_API(MonoType*, mono_type_get_generic_arg, (MonoType * type, int index))
-DO_API(MonoType*, mono_field_get_type_specific, (MonoClassField * field, MonoClass * owner))
-DO_API(void, mono_enter_internal_call,  (MonoInternalCallFrameOpaque * frame))
-DO_API(void, mono_exit_internal_call,  (MonoInternalCallFrameOpaque * frame))
-#endif
-
 #undef DO_API
 #undef DO_API_NO_RETURN
 #undef DO_API_OPTIONAL


### PR DESCRIPTION
I set `ENABLE_CORECLR=1` so that `MonoString` defined in `unity\unity-sources\Runtime\Mono\MonoTypes.h` would have the correct layout.