### PR TITLE
Add an AllocateString overload for InlineSString&

### DIFF
--- a/src/coreclr/vm/mono/mono_coreclr.cpp
+++ b/src/coreclr/vm/mono/mono_coreclr.cpp
@@ -102,6 +102,14 @@ struct MonoCustomAttrInfo_clr
     Assembly *assembly;
 };
 
+template <COUNT_T MEMSIZE>
+static STRINGREF AllocateString(const InlineSString<MEMSIZE>& sstr)
+{
+    STRINGREF strObj = AllocateString(sstr.GetCount());
+    memcpyNoGCRefs(strObj->GetBuffer(), sstr.GetUnicode(), sstr.GetCount() * sizeof(WCHAR));
+    return strObj;
+}
+
 class GCNativeFrame : public Frame
 {
     VPTR_VTABLE_CLASS(GCNativeFrame, Frame)


### PR DESCRIPTION
Calling AllocateString passing in an InlineSSString
will compile, but AllocateString overload that is
calling takes an SString.  This ends up calling the
SString(WCHAR*) conversion constructor, which means
we pay for another strlen & allocation.

To prevent us from accidentally hitting this again,
I've added local AllocateString that will take an
InlineString by reference.

On may machine this drops 1M `mono_new_string_wrapper` calls from 185ms to 109ms.