### PR TITLE
Set path on PEImage when loading from memory.

### DIFF
--- a/src/coreclr/vm/assemblynative.cpp
+++ b/src/coreclr/vm/assemblynative.cpp
@@ -330,11 +330,7 @@ extern "C" void QCALLTYPE AssemblyNative_GetLocation(QCall::AssemblyHandle pAsse
     BEGIN_QCALL;
 
     {
-#ifdef FEATURE_UNITY_ASSEMBLY_MEMORY_PATH
-        retString.Set(pAssembly->GetPath());
-#else
         retString.Set(pAssembly->GetPEAssembly()->GetPath());
-#endif
     }
 
     END_QCALL;

--- a/src/coreclr/vm/domainassembly.h
+++ b/src/coreclr/vm/domainassembly.h
@@ -286,25 +286,6 @@ public:
     DynamicMethodTable* GetDynamicMethodTable();
 #endif
 
- #ifdef FEATURE_UNITY_ASSEMBLY_MEMORY_PATH
-    // Unity loads assemblies from memory, so we can modify them on disk while they are loaded when users
-    // change scripts. But we still want them to point to their location on disk when queried by Assembly.Location.
-    // 
-    // But CoreCLR does not support assemblies loaded from memory with a custom path atm, so we need to add our own
-    // support. SA: https://github.com/dotnet/runtime/issues/12822
-    const SString &GetPath()
-    {
-        if (!m_CustomPath.IsEmpty())
-            return m_CustomPath;
-        return GetPEAssembly()->GetPath();
-    }
-    
-    void SetCustomPath(LPCSTR path)
-    {
-        m_CustomPath.SetUTF8(path);
-    }
-#endif
-
     DomainAssembly* GetNextDomainAssemblyInSameALC()
     {
         return m_NextDomainAssemblyInSameALC;
@@ -482,9 +463,6 @@ private:
     DebuggerAssemblyControlFlags    m_debuggerFlags;
     DWORD                       m_notifyflags;
     BOOL                        m_fDebuggerUnloadStarted;
-#ifdef FEATURE_UNITY_ASSEMBLY_MEMORY_PATH
-    SString m_CustomPath;
-#endif
 };
 
 #endif  // _DOMAINASSEMBLY_H_

--- a/src/coreclr/vm/mono/mono_coreclr.cpp
+++ b/src/coreclr/vm/mono/mono_coreclr.cpp
@@ -2075,7 +2075,9 @@ extern "C" EXPORT_API MonoImage* EXPORT_CC mono_image_open_from_data_with_name(c
 
     auto assembly = domainAssembly->GetAssembly();
 
-    assembly->GetDomainAssembly()->SetCustomPath(name);
+    auto peAssembly = assembly->GetPEAssembly();
+    auto peImage = peAssembly->GetPEImage();
+    peImage->SetPath(name);
 
     assembly->EnsureActive();
 

--- a/src/coreclr/vm/peimage.h
+++ b/src/coreclr/vm/peimage.h
@@ -137,6 +137,14 @@ public:
     const SString& GetPath();
     const SString& GetPathToLoad();
     LPCWSTR GetPathForErrorMessages() { return GetPath(); }
+ #ifdef FEATURE_UNITY_ASSEMBLY_MEMORY_PATH
+    // Unity loads assemblies from memory, so we can modify them on disk while they are loaded when users
+    // change scripts. But we still want them to point to their location on disk when queried by Assembly.Location.
+
+    // But CoreCLR does not support assemblies loaded from memory with a custom path atm, so we need to add our own
+    // support. SA: https://github.com/dotnet/runtime/issues/12822
+    void SetPath(LPCSTR path);
+#endif
 
     BOOL IsFile();
     BOOL IsInBundle() const;

--- a/src/coreclr/vm/peimage.inl
+++ b/src/coreclr/vm/peimage.inl
@@ -39,6 +39,16 @@ inline const SString& PEImage::GetPathToLoad()
     return IsInBundle() ? m_bundleFileLocation.Path() : m_path;
 }
 
+ #ifdef FEATURE_UNITY_ASSEMBLY_MEMORY_PATH
+inline void PEImage::SetPath(LPCSTR path)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+
+    _ASSERTE(m_path.IsEmpty());
+    m_path.SetUTF8(path);
+}
+#endif
+
 inline INT64 PEImage::GetOffset() const
 {
     LIMITED_METHOD_CONTRACT;


### PR DESCRIPTION
Adjustments from previous PR. Smaller changes and more correct
behavior since images loaded via memory end up having a CodeBase of
System.Private.CoreLib.dll.

Previous PR: https://github.com/Unity-Technologies/runtime/pull/4/commits/8201637605617e3bb2a7c60c03220cb0430a0bca