### PR TITLE
Update core runtime and library test sets to suit Unity use cases

### DIFF
--- a/.yamato/test_linux_x64.yml
+++ b/.yamato/test_linux_x64.yml
@@ -18,8 +18,8 @@ commands:
 #    cmake -DCMAKE_BUILD_TYPE=Release .
 #    cmake --build .
 #    ./mono_test_app
-  - ./build.sh -subset libs.tests -test -a x64 -c release -ci -ninja
-  - command: ./src/tests/build.sh x64 release ci
+  - ./build.sh -subset libs.tests -test /p:RunSmokeTestsOnly=true -a x64 -c release -ci -ninja
+  - command: ./src/tests/build.sh x64 release ci -tree:GC -tree:JIT -tree:baseservices -tree:interop -tree:reflection
     retries: 1
   - ./src/tests/run.sh x64 release
   - ./build.sh clr.paltests

--- a/.yamato/test_osx_arm64.yml
+++ b/.yamato/test_osx_arm64.yml
@@ -18,8 +18,8 @@ commands:
     cmake -DCMAKE_BUILD_TYPE=Release .
     cmake --build .
     ./mono_test_app
-  - LD_LIBRARY_PATH=/usr/local/opt/openssl/lib ./build.sh -subset libs.tests -test -a arm64 -c release -ci -ninja
-  - ./src/tests/build.sh arm64 release ci
+  - LD_LIBRARY_PATH=/usr/local/opt/openssl/lib ./build.sh -subset libs.tests -test /p:RunSmokeTestsOnly=true -a arm64 -c release -ci -ninja
+  - ./src/tests/build.sh arm64 release ci -tree:GC -tree:JIT -tree:baseservices -tree:interop -tree:reflection
   - ./src/tests/run.sh arm64 release
   - ./build.sh clr.paltests
   - ./artifacts/bin/coreclr/OSX.arm64.Debug/paltests/runpaltests.sh $(pwd)/artifacts/bin/coreclr/OSX.arm64.Debug/paltests

--- a/.yamato/test_osx_x64.yml
+++ b/.yamato/test_osx_x64.yml
@@ -18,8 +18,8 @@ commands:
     cmake -DCMAKE_BUILD_TYPE=Release .
     cmake --build .
     ./mono_test_app
-  - LD_LIBRARY_PATH=/usr/local/opt/openssl/lib ./build.sh -subset libs.tests -test -a x64 -c release -ci -ninja
-  - ./src/tests/build.sh x64 release ci
+  - LD_LIBRARY_PATH=/usr/local/opt/openssl/lib ./build.sh -subset libs.tests -test /p:RunSmokeTestsOnly=true -a x64 -c release -ci -ninja
+  - ./src/tests/build.sh x64 release ci -tree:GC -tree:JIT -tree:baseservices -tree:interop -tree:reflection
   - ./src/tests/run.sh x64 release
   - ./build.sh clr.paltests
   - ./artifacts/bin/coreclr/OSX.x64.Debug/paltests/runpaltests.sh $(pwd)/artifacts/bin/coreclr/OSX.x64.Debug/paltests

--- a/.yamato/test_windows_x64.yml
+++ b/.yamato/test_windows_x64.yml
@@ -18,8 +18,8 @@ commands:
     cmake .
     cmake --build . --config Release
     Release\mono_test_app.exe
-  - build.cmd libs.tests -test -a x64 -c release -ci
-  - src\tests\build.cmd x64 release ci
+  - build.cmd libs.tests -test /p:RunSmokeTestsOnly=true -a x64 -c release -ci
+  - src\tests\build.cmd x64 release ci tree GC tree JIT tree baseservices tree interop tree reflection
   - src\tests\run.cmd x64 release
 
 triggers:

--- a/.yamato/test_windows_x86.yml
+++ b/.yamato/test_windows_x86.yml
@@ -18,8 +18,8 @@ commands:
 #    cmake . -A Win32
 #    cmake --build . --config Release
 #    Release\mono_test_app.exe
-  - build.cmd libs.tests -test -a x86 -c release -ci
-  - src\tests\build.cmd x86 release ci
+  - build.cmd libs.tests -test /p:RunSmokeTestsOnly=true -a x86 -c release -ci
+  - src\tests\build.cmd x86 release ci tree GC tree JIT tree baseservices tree interop tree reflection
   - src\tests\run.cmd x86 release
 
 triggers:


### PR DESCRIPTION
The purpose of this PR is to modify test sets and sustain stable updates from upstream dotnet/runtime. Currently tests are failing and lead to the suspension of updates. 

Here are the main changes:
- For the libraries tests under https://github.com/dotnet/runtime/tree/main/src/libraries, we run just System.Runtime tests to validate that the runtime is generally working
- For the core runtime tests under https://github.com/dotnet/runtime/tree/main/src/tests, we run subsets including five tests: GC; JIT; baseservices;interop;reflection. Those subsets are chosen to ensure that the basic runtime behavior is correct. 
