### PR TITLE
Fix mono_image_loaded on Windows.

### DIFF
--- a/src/coreclr/vm/mono/mono_coreclr.cpp
+++ b/src/coreclr/vm/mono/mono_coreclr.cpp
@@ -1454,6 +1454,8 @@ struct LoadedImage{
         image = _image;
         domain = _domain;
         const char * namepos = strrchr(_name, '/');
+        if (!namepos)
+            namepos = strrchr(_name, '\\');
         if (namepos)
             _name = namepos + 1;
         name = (char*)malloc(strlen(_name) + 1);


### PR DESCRIPTION
Ensure the image cache splits name from path using both back slash
and forward slash to work correctly on Windows.