### PR TITLE
Pulling the build commands out into single scripts

### DIFF
--- a/.yamato/build_linux_x64.yml
+++ b/.yamato/build_linux_x64.yml
@@ -11,23 +11,8 @@ variables:
   ARTIFACT_FILENAME: {{globals.artifact_base_name}}-linux-x64.7z
 
 commands:
-  - mkdir artifacts
-  - curl https://public-stevedore.unity3d.com/r/public/7za-linux-x64/e6c75fb7ffda_e6a295cdcae3f74d315361883cf53f75141be2e739c020035f414a449d4876af.zip --output artifacts/7za-linux-x64.zip
-  - unzip artifacts/7za-linux-x64.zip -d artifacts/7za-linux-x64
-  - ./dotnet.sh build unity/managed.sln -c Release
-  - |
-    cd unity/unitygc
-    mkdir release
-    cd release
-    cmake -DCMAKE_BUILD_TYPE=Release ..
-    cmake --build .
-  - ./build.sh -subset clr+libs+libs -a x64 -c release -ci -ninja
-  - cp unity/unitygc/release/libunitygc.so artifacts/bin/microsoft.netcore.app.runtime.linux-x64/Release/runtimes/linux-x64/native
-  - cp artifacts/bin/unity-embed-host/Release/net6.0/unity-embed-host.dll artifacts/bin/microsoft.netcore.app.runtime.linux-x64/Release/runtimes/linux-x64/lib/net7.0
-  - cp artifacts/bin/unity-embed-host/Release/net6.0/unity-embed-host.dll artifacts/bin/microsoft.netcore.app.runtime.linux-x64/Release/runtimes/linux-x64/lib/net7.0
-  - cp LICENSE.md artifacts/bin/microsoft.netcore.app.runtime.linux-x64/Release/runtimes/linux-x64/.
-  - artifacts/7za-linux-x64/7za a artifacts/unity/$ARTIFACT_FILENAME ./artifacts/bin/microsoft.netcore.app.runtime.linux-x64/Release/runtimes/linux-x64/*
-
+  - ./.yamato/scripts/build_linux_x64.sh
+  
 artifacts:
   7z-archives:
     paths:

--- a/.yamato/build_osx_arm64.yml
+++ b/.yamato/build_osx_arm64.yml
@@ -11,23 +11,8 @@ variables:
   ARTIFACT_FILENAME: {{globals.artifact_base_name}}-osx-arm64.7z
 
 commands:
-  - mkdir artifacts
-  - curl https://public-stevedore.unity3d.com/r/public/7za-mac-x64/e6c75fb7ffda_5bd76652986a0e3756d1cfd7e84ce056a9e1dbfc5f70f0514a001f724c0fbad2.zip --output artifacts/7za-mac-x64.zip
-  - unzip artifacts/7za-mac-x64.zip -d artifacts/7za-mac-x64
-  - ./dotnet.sh build unity/managed.sln -c Release
-  - |
-    cd unity/unitygc
-    mkdir release
-    cd release
-    cmake -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_BUILD_TYPE=Release ..
-    cmake --build .
-  - LD_LIBRARY_PATH=/usr/local/opt/openssl/lib ./build.sh -subset clr+libs -a arm64 -c release -cross -ci -ninja /p:CrossBuild=true
-  - cp unity/unitygc/release/libunitygc.dylib artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Release/runtimes/osx-arm64/native
-  - cp artifacts/bin/unity-embed-host/Release/net6.0/unity-embed-host.dll artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Release/runtimes/osx-arm64/lib/net7.0
-  - cp artifacts/bin/unity-embed-host/Release/net6.0/unity-embed-host.pdb artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Release/runtimes/osx-arm64/lib/net7.0
-  - cp LICENSE.md artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Release/runtimes/osx-arm64/.
-  - artifacts/7za-mac-x64/7za a artifacts/unity/$ARTIFACT_FILENAME ./artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Release/runtimes/osx-arm64/*
-
+  - ./.yamato/scripts/build_osx_arm64.sh
+  
 # We don't test ARM64 yet, so let's build it on PRs targeting unity-main to make sure it builds at least
 triggers:
   pull_requests:

--- a/.yamato/build_osx_x64.yml
+++ b/.yamato/build_osx_x64.yml
@@ -11,23 +11,8 @@ variables:
   ARTIFACT_FILENAME: {{globals.artifact_base_name}}-osx-x64.7z
 
 commands:
-  - mkdir artifacts
-  - curl https://public-stevedore.unity3d.com/r/public/7za-mac-x64/e6c75fb7ffda_5bd76652986a0e3756d1cfd7e84ce056a9e1dbfc5f70f0514a001f724c0fbad2.zip --output artifacts/7za-mac-x64.zip
-  - unzip artifacts/7za-mac-x64.zip -d artifacts/7za-mac-x64
-  - ./dotnet.sh build unity/managed.sln -c Release
-  - |
-    cd unity/unitygc
-    mkdir release
-    cd release
-    cmake -DCMAKE_BUILD_TYPE=Release ..
-    cmake --build .
-  - LD_LIBRARY_PATH=/usr/local/opt/openssl/lib ./build.sh -subset clr+libs -a x64 -c release -ci -ninja
-  - cp unity/unitygc/release/libunitygc.dylib artifacts/bin/microsoft.netcore.app.runtime.osx-x64/Release/runtimes/osx-x64/native
-  - cp artifacts/bin/unity-embed-host/Release/net6.0/unity-embed-host.dll artifacts/bin/microsoft.netcore.app.runtime.osx-x64/Release/runtimes/osx-x64/lib/net7.0
-  - cp artifacts/bin/unity-embed-host/Release/net6.0/unity-embed-host.pdb artifacts/bin/microsoft.netcore.app.runtime.osx-x64/Release/runtimes/osx-x64/lib/net7.0
-  - cp LICENSE.md artifacts/bin/microsoft.netcore.app.runtime.osx-x64/Release/runtimes/osx-x64/.
-  - artifacts/7za-mac-x64/7za a artifacts/unity/$ARTIFACT_FILENAME ./artifacts/bin/microsoft.netcore.app.runtime.osx-x64/Release/runtimes/osx-x64/*
-
+  - ./.yamato/scripts/build_osx_x64.sh
+  
 artifacts:
   7z-archives:
     paths:

--- a/.yamato/build_osx_x64arm64.yml
+++ b/.yamato/build_osx_x64arm64.yml
@@ -15,13 +15,8 @@ dependencies:
   - path: .yamato/build_osx_x64.yml
 
 commands:
-  - curl https://public-stevedore.unity3d.com/r/public/7za-mac-x64/e6c75fb7ffda_5bd76652986a0e3756d1cfd7e84ce056a9e1dbfc5f70f0514a001f724c0fbad2.zip --output artifacts/7za-mac-x64.zip
-  - unzip artifacts/7za-mac-x64.zip -d artifacts/7za-mac-x64
-  - mkdir -p ./artifacts/bin/microsoft.netcore.app.runtime.osx-x64arm64/Release/runtimes/osx-x64arm64
-  - perl .yamato/scripts/the_liponator.pl ./artifacts/bin/microsoft.netcore.app.runtime.osx-x64/Release/runtimes/osx-x64 ./artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Release/runtimes/osx-arm64 ./artifacts/bin/microsoft.netcore.app.runtime.osx-x64arm64/Release/runtimes/osx-x64arm64
-  - cp LICENSE.md artifacts/bin/microsoft.netcore.app.runtime.osx-x64arm64/Release/runtimes/osx-x64arm64/.
-  - artifacts/7za-mac-x64/7za a artifacts/unity/$ARTIFACT_FILENAME ./artifacts/bin/microsoft.netcore.app.runtime.osx-x64arm64/Release/runtimes/osx-x64arm64/*
-
+  - ./.yamato/scripts/generate_osx_x64_arm64.sh
+  
 # We don't test x64+ARM64 yet, so let's build it on PRs targeting unity-main to make sure it builds at least
 triggers:
   pull_requests:

--- a/.yamato/build_windows_x64.yml
+++ b/.yamato/build_windows_x64.yml
@@ -11,19 +11,8 @@ variables:
   ARTIFACT_FILENAME: {{globals.artifact_base_name}}-win-x64.7z
 
 commands:
-  - dotnet build unity\managed.sln -c Release
-  - |
-    cd unity\unitygc
-    cmake .
-    cmake --build . --config Release
-  - build.cmd -subset clr+libs -a x64 -c release -ci
-  - copy unity\unitygc\Release\unitygc.dll artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\native
-  - copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.dll artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\lib\net7.0 
-  - copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.pdb artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\lib\net7.0 
-  - powershell .yamato\scripts\download_7z.ps1
-  - copy LICENSE.md artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64
-  - artifacts\7za-win-x64\7za.exe a artifacts\unity\%ARTIFACT_FILENAME% .\artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\*
-
+  - .yamato/scripts/build_windows_x64.cmd
+  
 artifacts:
   7z-archives:
     paths:

--- a/.yamato/build_windows_x86.yml
+++ b/.yamato/build_windows_x86.yml
@@ -11,19 +11,8 @@ variables:
   ARTIFACT_FILENAME: {{globals.artifact_base_name}}-win-x86.7z
 
 commands:
-  - dotnet build unity\managed.sln -c Release
-  - |
-    cd unity\unitygc
-    cmake . -A Win32
-    cmake --build . --config Release
-  - build.cmd -subset clr+libs -a x86 -c release -ci
-  - copy unity\unitygc\Release\unitygc.dll artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86\native
-  - copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.dll artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86\lib\net7.0
-  - copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.pdb artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86\lib\net7.0
-  - powershell .yamato\scripts\download_7z.ps1
-  - copy LICENSE.md artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86
-  - artifacts\7za-win-x64\7za.exe a artifacts\unity\%ARTIFACT_FILENAME% .\artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86\*
-
+  - .yamato/scripts/build_windows_x86.cmd
+  
 artifacts:
   7z-archives:
     paths:

--- a/.yamato/scripts/build_linux_x64.sh
+++ b/.yamato/scripts/build_linux_x64.sh
@@ -1,0 +1,19 @@
+# download 7-zip
+mkdir artifacts
+curl https://public-stevedore.unity3d.com/r/public/7za-linux-x64/e6c75fb7ffda_e6a295cdcae3f74d315361883cf53f75141be2e739c020035f414a449d4876af.zip --output artifacts/7za-linux-x64.zip
+unzip artifacts/7za-linux-x64.zip -d artifacts/7za-linux-x64
+# build solution
+./dotnet.sh build unity/managed.sln -c Release
+cd unity/unitygc
+mkdir release
+cd release
+cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake --build .
+cd ../../../
+# build subset library and core clr
+./build.sh -subset clr+libs+libs -a x64 -c release -ci -ninja
+cp unity/unitygc/release/libunitygc.so artifacts/bin/microsoft.netcore.app.runtime.linux-x64/Release/runtimes/linux-x64/native
+cp artifacts/bin/unity-embed-host/Release/net6.0/unity-embed-host.dll artifacts/bin/microsoft.netcore.app.runtime.linux-x64/Release/runtimes/linux-x64/lib/net7.0
+cp artifacts/bin/unity-embed-host/Release/net6.0/unity-embed-host.dll artifacts/bin/microsoft.netcore.app.runtime.linux-x64/Release/runtimes/linux-x64/lib/net7.0
+cp LICENSE.md artifacts/bin/microsoft.netcore.app.runtime.linux-x64/Release/runtimes/linux-x64/.
+artifacts/7za-linux-x64/7za a artifacts/unity/$ARTIFACT_FILENAME ./artifacts/bin/microsoft.netcore.app.runtime.linux-x64/Release/runtimes/linux-x64/*

--- a/.yamato/scripts/build_osx_arm64.sh
+++ b/.yamato/scripts/build_osx_arm64.sh
@@ -1,0 +1,19 @@
+# download 7-zip
+mkdir artifacts
+curl https://public-stevedore.unity3d.com/r/public/7za-mac-x64/e6c75fb7ffda_5bd76652986a0e3756d1cfd7e84ce056a9e1dbfc5f70f0514a001f724c0fbad2.zip --output artifacts/7za-mac-x64.zip
+unzip artifacts/7za-mac-x64.zip -d artifacts/7za-mac-x64
+# build solution
+./dotnet.sh build unity/managed.sln -c Release
+cd unity/unitygc
+mkdir release
+cd release
+cmake -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_BUILD_TYPE=Release ..
+cmake --build .
+cd ../../../
+# build subset library and core clr
+LD_LIBRARY_PATH=/usr/local/opt/openssl/lib ./build.sh -subset clr+libs -a arm64 -c release -cross -ci -ninja /p:CrossBuild=true
+cp unity/unitygc/release/libunitygc.dylib artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Release/runtimes/osx-arm64/native
+cp artifacts/bin/unity-embed-host/Release/net6.0/unity-embed-host.dll artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Release/runtimes/osx-arm64/lib/net7.0
+cp artifacts/bin/unity-embed-host/Release/net6.0/unity-embed-host.pdb artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Release/runtimes/osx-arm64/lib/net7.0
+cp LICENSE.md artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Release/runtimes/osx-arm64/.
+artifacts/7za-mac-x64/7za a artifacts/unity/$ARTIFACT_FILENAME ./artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Release/runtimes/osx-arm64/*

--- a/.yamato/scripts/build_osx_x64.sh
+++ b/.yamato/scripts/build_osx_x64.sh
@@ -1,0 +1,19 @@
+# download 7-zip
+mkdir artifacts
+curl https://public-stevedore.unity3d.com/r/public/7za-mac-x64/e6c75fb7ffda_5bd76652986a0e3756d1cfd7e84ce056a9e1dbfc5f70f0514a001f724c0fbad2.zip --output artifacts/7za-mac-x64.zip
+unzip artifacts/7za-mac-x64.zip -d artifacts/7za-mac-x64
+# build solution
+./dotnet.sh build unity/managed.sln -c Release
+cd unity/unitygc
+mkdir release
+cd release
+cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake --build .
+cd ../../../
+# build subset library and core clr
+LD_LIBRARY_PATH=/usr/local/opt/openssl/lib ./build.sh -subset clr+libs -a x64 -c release -ci -ninja
+cp unity/unitygc/release/libunitygc.dylib artifacts/bin/microsoft.netcore.app.runtime.osx-x64/Release/runtimes/osx-x64/native
+cp artifacts/bin/unity-embed-host/Release/net6.0/unity-embed-host.dll artifacts/bin/microsoft.netcore.app.runtime.osx-x64/Release/runtimes/osx-x64/lib/net7.0
+cp artifacts/bin/unity-embed-host/Release/net6.0/unity-embed-host.pdb artifacts/bin/microsoft.netcore.app.runtime.osx-x64/Release/runtimes/osx-x64/lib/net7.0
+cp LICENSE.md artifacts/bin/microsoft.netcore.app.runtime.osx-x64/Release/runtimes/osx-x64/.
+artifacts/7za-mac-x64/7za a artifacts/unity/$ARTIFACT_FILENAME ./artifacts/bin/microsoft.netcore.app.runtime.osx-x64/Release/runtimes/osx-x64/*

--- a/.yamato/scripts/build_windows_x64.cmd
+++ b/.yamato/scripts/build_windows_x64.cmd
@@ -1,0 +1,14 @@
+# build solution
+dotnet build unity\managed.sln -c Release
+cd unity\unitygc
+cmake .
+cmake --build . --config Release
+cd ../../
+# build subset library and core clr
+build.cmd -subset clr+libs -a x64 -c release -ci
+copy unity\unitygc\Release\unitygc.dll artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\native
+copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.dll artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\lib\net7.0 
+copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.pdb artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\lib\net7.0 
+powershell .yamato\scripts\download_7z.ps1
+copy LICENSE.md artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64
+artifacts\7za-win-x64\7za.exe a artifacts\unity\%ARTIFACT_FILENAME% .\artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\*

--- a/.yamato/scripts/build_windows_x86.cmd
+++ b/.yamato/scripts/build_windows_x86.cmd
@@ -1,0 +1,14 @@
+# build solution
+dotnet build unity\managed.sln -c Release
+cd unity\unitygc
+cmake . -A Win32
+cmake --build . --config Release
+cd ../../
+# build subset library and core clr
+build.cmd -subset clr+libs -a x86 -c release -ci
+copy unity\unitygc\Release\unitygc.dll artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86\native
+copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.dll artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86\lib\net7.0
+copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.pdb artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86\lib\net7.0
+powershell .yamato\scripts\download_7z.ps1
+copy LICENSE.md artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86
+artifacts\7za-win-x64\7za.exe a artifacts\unity\%ARTIFACT_FILENAME% .\artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86\*

--- a/.yamato/scripts/generate_osx_x64_arm64.sh
+++ b/.yamato/scripts/generate_osx_x64_arm64.sh
@@ -1,0 +1,8 @@
+# download 7-zip
+curl https://public-stevedore.unity3d.com/r/public/7za-mac-x64/e6c75fb7ffda_5bd76652986a0e3756d1cfd7e84ce056a9e1dbfc5f70f0514a001f724c0fbad2.zip --output artifacts/7za-mac-x64.zip
+unzip artifacts/7za-mac-x64.zip -d artifacts/7za-mac-x64
+# run the liponator script
+mkdir -p ./artifacts/bin/microsoft.netcore.app.runtime.osx-x64arm64/Release/runtimes/osx-x64arm64
+perl .yamato/scripts/the_liponator.pl ./artifacts/bin/microsoft.netcore.app.runtime.osx-x64/Release/runtimes/osx-x64 ./artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Release/runtimes/osx-arm64 ./artifacts/bin/microsoft.netcore.app.runtime.osx-x64arm64/Release/runtimes/osx-x64arm64
+cp LICENSE.md artifacts/bin/microsoft.netcore.app.runtime.osx-x64arm64/Release/runtimes/osx-x64arm64/.
+artifacts/7za-mac-x64/7za a artifacts/unity/$ARTIFACT_FILENAME ./artifacts/bin/microsoft.netcore.app.runtime.osx-x64arm64/Release/runtimes/osx-x64arm64/*

--- a/.yamato/scripts/test_linux_x64.sh
+++ b/.yamato/scripts/test_linux_x64.sh
@@ -1,0 +1,15 @@
+# build/run tests
+#  - dotnet build unity/managed.sln -c Release
+#  - |
+#    cd unity/embed_api_tests
+#    cmake -DCMAKE_BUILD_TYPE=Release .
+#    cmake --build .
+#    ./mono_test_app
+
+# run a small set of library test to ensure basic behavior
+./build.sh -subset libs.tests -test /p:RunSmokeTestsOnly=true -a x64 -c release -ci -ninja
+# run five sub-trees of core runtime tests
+./src/tests/build.sh x64 release ci -tree:GC -tree:JIT -tree:baseservices -tree:interop -tree:reflection
+./src/tests/run.sh x64 release
+./build.sh clr.paltests
+./artifacts/bin/coreclr/$(uname).x64.Debug/paltests/runpaltests.sh $(pwd)/artifacts/bin/coreclr/$(uname).x64.Debug/paltests

--- a/.yamato/scripts/test_osx_arm64.sh
+++ b/.yamato/scripts/test_osx_arm64.sh
@@ -1,0 +1,13 @@
+dotnet build unity/managed.sln -c Release
+cd unity/embed_api_tests
+cmake -DCMAKE_BUILD_TYPE=Release .
+cmake --build .
+./mono_test_app
+cd ../../
+# run a small set of library test to ensure basic behavior
+LD_LIBRARY_PATH=/usr/local/opt/openssl/lib ./build.sh -subset libs.tests -test /p:RunSmokeTestsOnly=true -a arm64 -c release -ci -ninja
+# run five sub-trees of core runtime tests
+./src/tests/build.sh arm64 release ci -tree:GC -tree:JIT -tree:baseservices -tree:interop -tree:reflection
+./src/tests/run.sh arm64 release
+./build.sh clr.paltests
+./artifacts/bin/coreclr/OSX.arm64.Debug/paltests/runpaltests.sh $(pwd)/artifacts/bin/coreclr/OSX.arm64.Debug/paltests

--- a/.yamato/scripts/test_osx_x64.sh
+++ b/.yamato/scripts/test_osx_x64.sh
@@ -1,0 +1,13 @@
+dotnet build unity/managed.sln -c Release
+cd unity/embed_api_tests
+cmake -DCMAKE_BUILD_TYPE=Release .
+cmake --build .
+./mono_test_app
+cd ../../
+# run a small set of library test to ensure basic behavior
+LD_LIBRARY_PATH=/usr/local/opt/openssl/lib ./build.sh -subset libs.tests -test /p:RunSmokeTestsOnly=true -a x64 -c release -ci -ninja
+# run five sub-trees of core runtime tests
+./src/tests/build.sh x64 release ci -tree:GC -tree:JIT -tree:baseservices -tree:interop -tree:reflection
+./src/tests/run.sh x64 release
+./build.sh clr.paltests
+./artifacts/bin/coreclr/OSX.x64.Debug/paltests/runpaltests.sh $(pwd)/artifacts/bin/coreclr/OSX.x64.Debug/paltests

--- a/.yamato/scripts/test_windows_x64.cmd
+++ b/.yamato/scripts/test_windows_x64.cmd
@@ -1,0 +1,12 @@
+# build/run tests
+dotnet build unity\managed.sln -c Release
+cd unity\embed_api_tests
+cmake .
+cmake --build . --config Release
+Release\mono_test_app.exe
+cd ../../
+# run a small set of library test to ensure basic behavior
+build.cmd libs.tests -test /p:RunSmokeTestsOnly=true -a x64 -c release -ci
+# run five sub-trees of core runtime tests
+src\tests\build.cmd x64 release ci tree GC tree JIT tree baseservices tree interop tree reflection
+src\tests\run.cmd x64 release

--- a/.yamato/scripts/test_windows_x86.cmd
+++ b/.yamato/scripts/test_windows_x86.cmd
@@ -1,0 +1,13 @@
+# build/run tests
+dotnet build unity\managed.sln -c Release
+#  - |
+#    cd unity\embed_api_tests
+#    cmake . -A Win32
+#    cmake --build . --config Release
+#    Release\mono_test_app.exe
+
+# run a small set of library test to ensure basic behavior
+build.cmd libs.tests -test /p:RunSmokeTestsOnly=true -a x86 -c release -ci
+# run five sub-trees of core runtime tests
+src\tests\build.cmd x86 release ci tree GC tree JIT tree baseservices tree interop tree reflection
+src\tests\run.cmd x86 release

--- a/.yamato/test_linux_x64.yml
+++ b/.yamato/test_linux_x64.yml
@@ -11,20 +11,8 @@ dependencies:
   - path: .yamato/build_linux_x64.yml
 
 commands:
-# build/run tests
-#  - dotnet build unity/managed.sln -c Release
-#  - |
-#    cd unity/embed_api_tests
-#    cmake -DCMAKE_BUILD_TYPE=Release .
-#    cmake --build .
-#    ./mono_test_app
-  - ./build.sh -subset libs.tests -test /p:RunSmokeTestsOnly=true -a x64 -c release -ci -ninja
-  - command: ./src/tests/build.sh x64 release ci -tree:GC -tree:JIT -tree:baseservices -tree:interop -tree:reflection
-    retries: 1
-  - ./src/tests/run.sh x64 release
-  - ./build.sh clr.paltests
-  - ./artifacts/bin/coreclr/$(uname).x64.Debug/paltests/runpaltests.sh $(pwd)/artifacts/bin/coreclr/$(uname).x64.Debug/paltests
-
+  - ./.yamato/scripts/test_linux_x64.sh
+  
 triggers:
   pull_requests:
     - targets:

--- a/.yamato/test_osx_arm64.yml
+++ b/.yamato/test_osx_arm64.yml
@@ -12,17 +12,7 @@ dependencies:
 
 commands:
 # build/run tests
-  - dotnet build unity/managed.sln -c Release
-  - |
-    cd unity/embed_api_tests
-    cmake -DCMAKE_BUILD_TYPE=Release .
-    cmake --build .
-    ./mono_test_app
-  - LD_LIBRARY_PATH=/usr/local/opt/openssl/lib ./build.sh -subset libs.tests -test /p:RunSmokeTestsOnly=true -a arm64 -c release -ci -ninja
-  - ./src/tests/build.sh arm64 release ci -tree:GC -tree:JIT -tree:baseservices -tree:interop -tree:reflection
-  - ./src/tests/run.sh arm64 release
-  - ./build.sh clr.paltests
-  - ./artifacts/bin/coreclr/OSX.arm64.Debug/paltests/runpaltests.sh $(pwd)/artifacts/bin/coreclr/OSX.arm64.Debug/paltests
+  - ./.yamato/scripts/test_osx_arm64.sh
 
 ## Don't run OSX ARM64 tests for PRs until we have hardware to actually run it
 # triggers:

--- a/.yamato/test_osx_x64.yml
+++ b/.yamato/test_osx_x64.yml
@@ -12,18 +12,8 @@ dependencies:
 
 commands:
 # build/run tests
-  - dotnet build unity/managed.sln -c Release
-  - |
-    cd unity/embed_api_tests
-    cmake -DCMAKE_BUILD_TYPE=Release .
-    cmake --build .
-    ./mono_test_app
-  - LD_LIBRARY_PATH=/usr/local/opt/openssl/lib ./build.sh -subset libs.tests -test /p:RunSmokeTestsOnly=true -a x64 -c release -ci -ninja
-  - ./src/tests/build.sh x64 release ci -tree:GC -tree:JIT -tree:baseservices -tree:interop -tree:reflection
-  - ./src/tests/run.sh x64 release
-  - ./build.sh clr.paltests
-  - ./artifacts/bin/coreclr/OSX.x64.Debug/paltests/runpaltests.sh $(pwd)/artifacts/bin/coreclr/OSX.x64.Debug/paltests
-
+  - ./.yamato/scripts/test_osx_x64.sh
+  
 triggers:
   pull_requests:
     - targets:

--- a/.yamato/test_windows_x64.yml
+++ b/.yamato/test_windows_x64.yml
@@ -12,16 +12,8 @@ dependencies:
 
 commands:
 # build/run tests
-  - dotnet build unity\managed.sln -c Release
-  - |
-    cd unity\embed_api_tests
-    cmake .
-    cmake --build . --config Release
-    Release\mono_test_app.exe
-  - build.cmd libs.tests -test /p:RunSmokeTestsOnly=true -a x64 -c release -ci
-  - src\tests\build.cmd x64 release ci tree GC tree JIT tree baseservices tree interop tree reflection
-  - src\tests\run.cmd x64 release
-
+  - .yamato/scripts/test_windows_x64.cmd
+  
 triggers:
   pull_requests:
     - targets:

--- a/.yamato/test_windows_x86.yml
+++ b/.yamato/test_windows_x86.yml
@@ -11,16 +11,7 @@ dependencies:
   - path: .yamato/build_windows_x86.yml
 
 commands:
-# build/run tests
-  - dotnet build unity\managed.sln -c Release
-#  - |
-#    cd unity\embed_api_tests
-#    cmake . -A Win32
-#    cmake --build . --config Release
-#    Release\mono_test_app.exe
-  - build.cmd libs.tests -test /p:RunSmokeTestsOnly=true -a x86 -c release -ci
-  - src\tests\build.cmd x86 release ci tree GC tree JIT tree baseservices tree interop tree reflection
-  - src\tests\run.cmd x86 release
+  - .yamato/scripts/test_windows_x86.cmd
 
 triggers:
   pull_requests:

--- a/unity/README.md
+++ b/unity/README.md
@@ -15,3 +15,8 @@ When a pull request is open against this fork, we should determine if the change
 Assuming the branch with changes to upstream is named `great-new-feature` then a new branch of upstream [`main`](https://github.com/dotnet/runtime/tree/main) named `upstream-great-new-feature` should be created. Each commit from `great-new-feature` should be cherry-picked `upstream-great-new-feature`, and then a pull request should be opened from `upstream-great-new-feature` to [`main`](https://github.com/dotnet/runtime/tree/main) in the upstream repository.
 
 It is acceptable to _merge_ changes to this fork from `great-new-feature` before `upstream-great-new-feature` is merged, but we should at least _open_ an upstream pull request first.
+
+
+## Running yamato test scripts for local development purpose
+
+In unity/tests-scripts, there are four scripts (linux x64, osx x64, windows x64, windows x86) to run the [`yamato checks`](https://github.com/Unity-Technologies/runtime/tree/unity-main/.yamato) locally. Those scripts combine the build and test processes for each platform. 

--- a/unity/test-scripts/build_test_linux_x64.sh
+++ b/unity/test-scripts/build_test_linux_x64.sh
@@ -1,0 +1,3 @@
+#run the build and test scripts of yamato files
+./../../.yamato/scripts/build_linux_x64.sh
+./../../.yamato/scripts/test_linux_x64.sh

--- a/unity/test-scripts/build_test_osx_x64.sh
+++ b/unity/test-scripts/build_test_osx_x64.sh
@@ -1,0 +1,3 @@
+#run the build and test scripts of yamato files
+./../../.yamato/scripts/build_osx_x64.sh
+./../../.yamato/scripts/test_osx_x64.sh

--- a/unity/test-scripts/build_test_windows_x64.cmd
+++ b/unity/test-scripts/build_test_windows_x64.cmd
@@ -1,0 +1,3 @@
+#run the build and test scripts of yamato files
+../../.yamato/scripts/build_windows_x64.cmd
+../../.yamato/scripts/test_windows_x64.cmd

--- a/unity/test-scripts/build_test_windows_x86.cmd
+++ b/unity/test-scripts/build_test_windows_x86.cmd
@@ -1,0 +1,3 @@
+#run the build and test scripts of yamato files
+../../.yamato/scripts/build_windows_x86.cmd
+../../.yamato/scripts/test_windows_x86.cmd


### PR DESCRIPTION
This PR pulls the build commands of yamato checks out into single scripts. The purpose is to organize the code and make it easier to use for local development. 

Changes summary:
1. Create scripts for each platform under .yamato/scripts
2. modify the yamato yaml files to use the scripts
3. add the unity/yamato-tests-scripts directory and create scripts for local development usages
4. update the README file 