### PR TITLE
Allow the Windows dotnet commands to work in a batch file

### DIFF
--- a/.yamato/build_windows_x64.yml
+++ b/.yamato/build_windows_x64.yml
@@ -12,7 +12,10 @@ variables:
 
 commands:
   - .yamato/scripts/build_windows_x64.cmd
-  
+  - powershell .yamato\scripts\download_7z.ps1
+  - copy LICENSE.md artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64
+  - artifacts\7za-win-x64\7za.exe a artifacts\unity\%ARTIFACT_FILENAME% .\artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\*
+
 artifacts:
   7z-archives:
     paths:

--- a/.yamato/build_windows_x86.yml
+++ b/.yamato/build_windows_x86.yml
@@ -12,7 +12,10 @@ variables:
 
 commands:
   - .yamato/scripts/build_windows_x86.cmd
-  
+  - powershell .yamato\scripts\download_7z.ps1
+  - copy LICENSE.md artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86
+  - artifacts\7za-win-x64\7za.exe a artifacts\unity\%ARTIFACT_FILENAME% .\artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86\*
+
 artifacts:
   7z-archives:
     paths:

--- a/.yamato/scripts/build_windows_x64.cmd
+++ b/.yamato/scripts/build_windows_x64.cmd
@@ -1,5 +1,5 @@
 rem build solution
-dotnet build unity\managed.sln -c Release
+cmd /c dotnet build unity\managed.sln -c Release
 cd unity\unitygc
 cmake .
 cmake --build . --config Release
@@ -7,8 +7,5 @@ cd ../../
 rem build subset library and core clr
 build.cmd -subset clr+libs -a x64 -c release -ci
 copy unity\unitygc\Release\unitygc.dll artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\native
-copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.dll artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\lib\net7.0 
-copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.pdb artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\lib\net7.0 
-powershell .yamato\scripts\download_7z.ps1
-copy LICENSE.md artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64
-artifacts\7za-win-x64\7za.exe a artifacts\unity\%ARTIFACT_FILENAME% .\artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\*
+copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.dll artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\lib\net7.0
+copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.pdb artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\lib\net7.0

--- a/.yamato/scripts/build_windows_x86.cmd
+++ b/.yamato/scripts/build_windows_x86.cmd
@@ -1,5 +1,5 @@
 rem build solution
-dotnet build unity\managed.sln -c Release
+cmd /c dotnet build unity\managed.sln -c Release
 cd unity\unitygc
 cmake . -A Win32
 cmake --build . --config Release
@@ -9,6 +9,3 @@ build.cmd -subset clr+libs -a x86 -c release -ci
 copy unity\unitygc\Release\unitygc.dll artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86\native
 copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.dll artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86\lib\net7.0
 copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.pdb artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86\lib\net7.0
-powershell .yamato\scripts\download_7z.ps1
-copy LICENSE.md artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86
-artifacts\7za-win-x64\7za.exe a artifacts\unity\%ARTIFACT_FILENAME% .\artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86\*

--- a/.yamato/scripts/test_windows_x64.cmd
+++ b/.yamato/scripts/test_windows_x64.cmd
@@ -6,7 +6,7 @@ cmake --build . --config Release
 Release\mono_test_app.exe
 cd ../../
 rem run a small set of library test to ensure basic behavior
-build.cmd libs.tests -test /p:RunSmokeTestsOnly=true -a x64 -c release -ci
+cmd /c build.cmd libs.tests -test /p:RunSmokeTestsOnly=true -a x64 -c release -ci
 rem run five sub-trees of core runtime tests
-src\tests\build.cmd x64 release ci tree GC tree JIT tree baseservices tree interop tree reflection
-src\tests\run.cmd x64 release
+cmd /c src\tests\build.cmd x64 release ci tree GC tree JIT tree baseservices tree interop tree reflection
+cmd /c src\tests\run.cmd x64 release

--- a/.yamato/scripts/test_windows_x64.cmd
+++ b/.yamato/scripts/test_windows_x64.cmd
@@ -1,5 +1,5 @@
 rem build/run tests
-dotnet build unity\managed.sln -c Release
+cmd /c dotnet build unity\managed.sln -c Release
 cd unity\embed_api_tests
 cmake .
 cmake --build . --config Release

--- a/.yamato/scripts/test_windows_x86.cmd
+++ b/.yamato/scripts/test_windows_x86.cmd
@@ -1,5 +1,5 @@
 rem build/run tests
-dotnet build unity\managed.sln -c Release
+cmd /c dotnet build unity\managed.sln -c Release
 rem  - |
 rem    cd unity\embed_api_tests
 rem    cmake . -A Win32

--- a/.yamato/scripts/test_windows_x86.cmd
+++ b/.yamato/scripts/test_windows_x86.cmd
@@ -7,7 +7,7 @@ rem    cmake --build . --config Release
 rem    Release\mono_test_app.exe
 
 rem run a small set of library test to ensure basic behavior
-build.cmd libs.tests -test /p:RunSmokeTestsOnly=true -a x86 -c release -ci
+cmd /c build.cmd libs.tests -test /p:RunSmokeTestsOnly=true -a x86 -c release -ci
 rem run five sub-trees of core runtime tests
-src\tests\build.cmd x86 release ci tree GC tree JIT tree baseservices tree interop tree reflection
-src\tests\run.cmd x86 release
+cmd /c src\tests\build.cmd x86 release ci tree GC tree JIT tree baseservices tree interop tree reflection
+cmd /c src\tests\run.cmd x86 release


### PR DESCRIPTION
The dotnet command should be run from a separate cmd invocation to avoid
the batch file from exiting early after dotnet completes.

Also, move the artifact creation steps for build jobs back to the
Yamato script, as they usually only happen on Yamato.