### PR TITLE
Mask bit on pinned gchandles in embedding API.

### DIFF
--- a/unity/coreclr-test/test.cs
+++ b/unity/coreclr-test/test.cs
@@ -516,6 +516,16 @@ namespace TestDll
             
             return null;
         }
+
+        public static IntPtr GCHandleAlloc(object o, GCHandleType type)
+        {
+            return (IntPtr)GCHandle.Alloc(o, type);
+        }
+
+        public static object GCHandleGetTarget(IntPtr p)
+        {
+            return ((GCHandle)p).Target;
+        }
     }
 
     public class DerivedClass : TestClass


### PR DESCRIPTION
This matches behavior of managed GCHandle struct, and enables the IntPtr
representation of GCHandle to be passed between embedding API and
managed API.