### PR TITLE
Apply latest Yamato and build script changes

### DIFF
--- a/.yamato/build_windows_x64.yml
+++ b/.yamato/build_windows_x64.yml
@@ -4,7 +4,7 @@ name: Build Windows x64
 
 agent:
   type: Unity::VM
-  image: platform-foundation/windows-vs2019-il2cpp-bokken:v1.1.7-1038262
+  image: burst/burst-base:1.0.8-1195360
   flavor: b1.xlarge
 
 variables:

--- a/.yamato/build_windows_x86.yml
+++ b/.yamato/build_windows_x86.yml
@@ -4,7 +4,7 @@ name: Build Windows x86
 
 agent:
   type: Unity::VM
-  image: platform-foundation/windows-vs2019-il2cpp-bokken:v1.1.7-1038262
+  image: burst/burst-base:1.0.8-1195360
   flavor: b1.xlarge
 
 variables:

--- a/.yamato/publish_to_stevedore_public.yml
+++ b/.yamato/publish_to_stevedore_public.yml
@@ -1,9 +1,20 @@
 name: Publish To Stevedore (Public)
 
+agent:
+  type: Unity::VM
+  image: platform-foundation/linux-ubuntu-18.04-mono-bokken:latest
+  flavor: b1.large
+
 variables:
   STEVEDORE_REPO: public
 
 dependencies:
-  - .yamato/publish_to_stevedore_linux.yml
-  - .yamato/publish_to_stevedore_osx.yml
-  - .yamato/publish_to_stevedore_windows.yml
+  - .yamato/build_linux_x64.yml
+  - .yamato/build_osx_x64arm64.yml
+  - .yamato/build_windows_x86.yml
+  - .yamato/build_windows_x64.yml
+
+commands:
+  - curl -sSo StevedoreUpload "$STEVEDORE_UPLOAD_TOOL_LINUX_X64_URL"
+  - chmod +x StevedoreUpload
+  - ./StevedoreUpload --version-len=12 --repo=$STEVEDORE_REPO --version="$GIT_REVISION" artifacts/unity/*

--- a/.yamato/publish_to_stevedore_testing.yml
+++ b/.yamato/publish_to_stevedore_testing.yml
@@ -1,9 +1,20 @@
 name: Publish To Stevedore (Testing)
 
+agent:
+  type: Unity::VM
+  image: platform-foundation/linux-ubuntu-18.04-mono-bokken:latest
+  flavor: b1.large
+
 variables:
   STEVEDORE_REPO: testing
 
 dependencies:
-  - .yamato/publish_to_stevedore_linux.yml
-  - .yamato/publish_to_stevedore_osx.yml
-  - .yamato/publish_to_stevedore_windows.yml
+  - .yamato/build_linux_x64.yml
+  - .yamato/build_osx_x64arm64.yml
+  - .yamato/build_windows_x86.yml
+  - .yamato/build_windows_x64.yml
+
+commands:
+  - curl -sSo StevedoreUpload "$STEVEDORE_UPLOAD_TOOL_LINUX_X64_URL"
+  - chmod +x StevedoreUpload
+  - ./StevedoreUpload --version-len=12 --repo=$STEVEDORE_REPO --version="$GIT_REVISION" artifacts/unity/*

--- a/.yamato/scripts/build_linux_x64.sh
+++ b/.yamato/scripts/build_linux_x64.sh
@@ -1,19 +1,57 @@
-# download 7-zip
-mkdir artifacts
+#!/bin/sh
+set -e
+
+echo "*****************************"
+echo "Unity: Starting CoreCLR build"
+echo "*****************************"
+
+echo
+echo "************************"
+echo "Unity: Downloading 7-zip"
+echo "************************"
+echo
+mkdir -p artifacts
 curl https://public-stevedore.unity3d.com/r/public/7za-linux-x64/e6c75fb7ffda_e6a295cdcae3f74d315361883cf53f75141be2e739c020035f414a449d4876af.zip --output artifacts/7za-linux-x64.zip
 unzip artifacts/7za-linux-x64.zip -d artifacts/7za-linux-x64
-# build solution
+
+echo
+echo "******************************"
+echo "Unity: Building embedding host"
+echo "******************************"
+echo
 ./dotnet.sh build unity/managed.sln -c Release
+
+echo
+echo "***********************"
+echo "Unity: Building Null GC"
+echo "***********************"
+echo
 cd unity/unitygc
-mkdir release
+mkdir -p release
 cd release
 cmake -DCMAKE_BUILD_TYPE=Release ..
 cmake --build .
 cd ../../../
-# build subset library and core clr
+
+echo
+echo "*******************************"
+echo "Unity: Building CoreCLR runtime"
+echo "*******************************"
+echo
 ./build.sh -subset clr+libs+libs -a x64 -c release -ci -ninja
+
+echo
+echo "*******************************"
+echo "Unity: Copying built artifacts"
+echo "*******************************"
+echo
 cp unity/unitygc/release/libunitygc.so artifacts/bin/microsoft.netcore.app.runtime.linux-x64/Release/runtimes/linux-x64/native
 cp artifacts/bin/unity-embed-host/Release/net6.0/unity-embed-host.dll artifacts/bin/microsoft.netcore.app.runtime.linux-x64/Release/runtimes/linux-x64/lib/net7.0
 cp artifacts/bin/unity-embed-host/Release/net6.0/unity-embed-host.dll artifacts/bin/microsoft.netcore.app.runtime.linux-x64/Release/runtimes/linux-x64/lib/net7.0
 cp LICENSE.md artifacts/bin/microsoft.netcore.app.runtime.linux-x64/Release/runtimes/linux-x64/.
 artifacts/7za-linux-x64/7za a artifacts/unity/$ARTIFACT_FILENAME ./artifacts/bin/microsoft.netcore.app.runtime.linux-x64/Release/runtimes/linux-x64/*
+
+echo
+echo "*********************************"
+echo "Unity: Built CoreCLR successfully"
+echo "*********************************"

--- a/.yamato/scripts/build_osx_arm64.sh
+++ b/.yamato/scripts/build_osx_arm64.sh
@@ -1,19 +1,57 @@
-# download 7-zip
-mkdir artifacts
+#!/bin/sh
+set -e
+
+echo "*****************************"
+echo "Unity: Starting CoreCLR build"
+echo "*****************************"
+
+echo
+echo "************************"
+echo "Unity: Downloading 7-zip"
+echo "************************"
+echo
+mkdir -p artifacts
 curl https://public-stevedore.unity3d.com/r/public/7za-mac-x64/e6c75fb7ffda_5bd76652986a0e3756d1cfd7e84ce056a9e1dbfc5f70f0514a001f724c0fbad2.zip --output artifacts/7za-mac-x64.zip
 unzip artifacts/7za-mac-x64.zip -d artifacts/7za-mac-x64
-# build solution
+
+echo
+echo "******************************"
+echo "Unity: Building embedding host"
+echo "******************************"
+echo
 ./dotnet.sh build unity/managed.sln -c Release
+
+echo
+echo "***********************"
+echo "Unity: Building Null GC"
+echo "***********************"
+echo
 cd unity/unitygc
-mkdir release
+mkdir -p release
 cd release
 cmake -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_BUILD_TYPE=Release ..
 cmake --build .
 cd ../../../
-# build subset library and core clr
+
+echo
+echo "*******************************"
+echo "Unity: Building CoreCLR runtime"
+echo "*******************************"
+echo
 LD_LIBRARY_PATH=/usr/local/opt/openssl/lib ./build.sh -subset clr+libs -a arm64 -c release -cross -ci -ninja /p:CrossBuild=true
+
+echo
+echo "*******************************"
+echo "Unity: Copying built artifacts"
+echo "*******************************"
+echo
 cp unity/unitygc/release/libunitygc.dylib artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Release/runtimes/osx-arm64/native
 cp artifacts/bin/unity-embed-host/Release/net6.0/unity-embed-host.dll artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Release/runtimes/osx-arm64/lib/net7.0
 cp artifacts/bin/unity-embed-host/Release/net6.0/unity-embed-host.pdb artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Release/runtimes/osx-arm64/lib/net7.0
 cp LICENSE.md artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Release/runtimes/osx-arm64/.
 artifacts/7za-mac-x64/7za a artifacts/unity/$ARTIFACT_FILENAME ./artifacts/bin/microsoft.netcore.app.runtime.osx-arm64/Release/runtimes/osx-arm64/*
+
+echo
+echo "*********************************"
+echo "Unity: Built CoreCLR successfully"
+echo "*********************************"

--- a/.yamato/scripts/build_osx_x64.sh
+++ b/.yamato/scripts/build_osx_x64.sh
@@ -1,19 +1,57 @@
-# download 7-zip
-mkdir artifacts
+#!/bin/sh
+set -e
+
+echo "*****************************"
+echo "Unity: Starting CoreCLR build"
+echo "*****************************"
+
+echo
+echo "************************"
+echo "Unity: Downloading 7-zip"
+echo "************************"
+echo
+mkdir -p artifacts
 curl https://public-stevedore.unity3d.com/r/public/7za-mac-x64/e6c75fb7ffda_5bd76652986a0e3756d1cfd7e84ce056a9e1dbfc5f70f0514a001f724c0fbad2.zip --output artifacts/7za-mac-x64.zip
-unzip artifacts/7za-mac-x64.zip -d artifacts/7za-mac-x64
-# build solution
+unzip -o artifacts/7za-mac-x64.zip -d artifacts/7za-mac-x64
+
+echo
+echo "******************************"
+echo "Unity: Building embedding host"
+echo "******************************"
+echo
 ./dotnet.sh build unity/managed.sln -c Release
+
+echo
+echo "***********************"
+echo "Unity: Building Null GC"
+echo "***********************"
+echo
 cd unity/unitygc
-mkdir release
+mkdir -p release
 cd release
 cmake -DCMAKE_BUILD_TYPE=Release ..
 cmake --build .
 cd ../../../
-# build subset library and core clr
+
+echo
+echo "*******************************"
+echo "Unity: Building CoreCLR runtime"
+echo "*******************************"
+echo
 LD_LIBRARY_PATH=/usr/local/opt/openssl/lib ./build.sh -subset clr+libs -a x64 -c release -ci -ninja
+
+echo
+echo "*******************************"
+echo "Unity: Copying built artifacts"
+echo "*******************************"
+echo
 cp unity/unitygc/release/libunitygc.dylib artifacts/bin/microsoft.netcore.app.runtime.osx-x64/Release/runtimes/osx-x64/native
 cp artifacts/bin/unity-embed-host/Release/net6.0/unity-embed-host.dll artifacts/bin/microsoft.netcore.app.runtime.osx-x64/Release/runtimes/osx-x64/lib/net7.0
 cp artifacts/bin/unity-embed-host/Release/net6.0/unity-embed-host.pdb artifacts/bin/microsoft.netcore.app.runtime.osx-x64/Release/runtimes/osx-x64/lib/net7.0
 cp LICENSE.md artifacts/bin/microsoft.netcore.app.runtime.osx-x64/Release/runtimes/osx-x64/.
 artifacts/7za-mac-x64/7za a artifacts/unity/$ARTIFACT_FILENAME ./artifacts/bin/microsoft.netcore.app.runtime.osx-x64/Release/runtimes/osx-x64/*
+
+echo
+echo "*********************************"
+echo "Unity: Built CoreCLR successfully"
+echo "*********************************"

--- a/.yamato/scripts/build_windows_x64.cmd
+++ b/.yamato/scripts/build_windows_x64.cmd
@@ -1,11 +1,53 @@
-rem build solution
-cmd /c dotnet build unity\managed.sln -c Release
-cd unity\unitygc
-cmake .
-cmake --build . --config Release
-cd ../../
-rem build subset library and core clr
-build.cmd -subset clr+libs -a x64 -c release -ci
-copy unity\unitygc\Release\unitygc.dll artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\native
-copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.dll artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\lib\net7.0
-copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.pdb artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\lib\net7.0
+@echo off
+
+echo *****************************
+echo Unity: Starting CoreCLR build
+echo *****************************
+
+echo.
+echo ******************************
+echo Unity: Building embedding host
+echo ******************************
+echo.
+cmd /c dotnet build unity\managed.sln -c Release || goto :error
+
+echo.
+echo ***********************
+echo Unity: Building Null GC
+echo ***********************
+echo.
+cd unity\unitygc || goto :error
+cmake . || goto :error
+cmake --build . --config Release || goto :error
+cd ../../ || goto :error
+
+echo.
+echo *******************************
+echo Unity: Building CoreCLR runtime
+echo *******************************
+echo.
+call build.cmd -subset clr+libs -a x64 -c release -ci || goto :error
+
+echo.
+echo ******************************
+echo Unity: Copying built artifacts
+echo ******************************
+echo.
+copy unity\unitygc\Release\unitygc.dll artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\native || goto :error
+copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.dll artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\lib\net7.0 || goto :error
+copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.pdb artifacts\bin\microsoft.netcore.app.runtime.win-x64\Release\runtimes\win-x64\lib\net7.0 || goto :error
+
+rem Every thing succeeded - jump to the end of the file and return a 0 exit code
+echo.
+echo *********************************
+echo Unity: Built CoreCLR successfully
+echo *********************************
+goto :EOF
+
+rem If we get here, one of the commands above failed
+:error
+echo.
+echo ******************************
+echo Unity: Failed to build CoreCLR
+echo ******************************
+exit /b %errorlevel%

--- a/.yamato/scripts/build_windows_x86.cmd
+++ b/.yamato/scripts/build_windows_x86.cmd
@@ -1,11 +1,53 @@
-rem build solution
-cmd /c dotnet build unity\managed.sln -c Release
-cd unity\unitygc
-cmake . -A Win32
-cmake --build . --config Release
-cd ../../
-rem build subset library and core clr
-build.cmd -subset clr+libs -a x86 -c release -ci
-copy unity\unitygc\Release\unitygc.dll artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86\native
-copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.dll artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86\lib\net7.0
-copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.pdb artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86\lib\net7.0
+@echo off
+
+echo *****************************
+echo Unity: Starting CoreCLR build
+echo *****************************
+
+echo.
+echo ******************************
+echo Unity: Building embedding host
+echo ******************************
+echo.
+cmd /c dotnet build unity\managed.sln -c Release || goto :error
+
+echo.
+echo ***********************
+echo Unity: Building Null GC
+echo ***********************
+echo.
+cd unity\unitygc || goto :error
+cmake . -A Win32 || goto :error
+cmake --build . --config Release || goto :error
+cd ../../ || goto :error
+
+echo.
+echo *******************************
+echo Unity: Building CoreCLR runtime
+echo *******************************
+echo.
+cmd /c build.cmd -subset clr+libs -a x86 -c release -ci || goto :error
+
+echo.
+echo ******************************
+echo Unity: Copying built artifacts
+echo ******************************
+echo.
+copy unity\unitygc\Release\unitygc.dll artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86\native || goto :error
+copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.dll artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86\lib\net7.0 || goto :error
+copy artifacts\bin\unity-embed-host\Release\net6.0\unity-embed-host.pdb artifacts\bin\microsoft.netcore.app.runtime.win-x86\Release\runtimes\win-x86\lib\net7.0 || goto :error
+
+rem Every thing succeeded - jump to the end of the file and return a 0 exit code
+echo.
+echo *********************************
+echo Unity: Built CoreCLR successfully
+echo *********************************
+goto :EOF
+
+rem If we get here, one of the commands above failed
+:error
+echo.
+echo ******************************
+echo Unity: Failed to build CoreCLR
+echo ******************************
+exit /b %errorlevel%

--- a/.yamato/scripts/test_linux_x64.sh
+++ b/.yamato/scripts/test_linux_x64.sh
@@ -1,3 +1,15 @@
+#!/bin/sh
+set -e
+
+echo "*****************************"
+echo "Unity: Starting CoreCLR tests"
+echo "*****************************"
+
+echo
+echo "***********************************"
+echo "Unity: Skipping embedding API tests"
+echo "***********************************"
+echo
 # build/run tests
 #  - dotnet build unity/managed.sln -c Release
 #  - |
@@ -6,10 +18,30 @@
 #    cmake --build .
 #    ./mono_test_app
 
-# run a small set of library test to ensure basic behavior
+echo
+echo "**********************************"
+echo "Unity: Running class library tests"
+echo "**********************************"
+echo
 ./build.sh -subset libs.tests -test /p:RunSmokeTestsOnly=true -a x64 -c release -ci -ninja
-# run five sub-trees of core runtime tests
-./src/tests/build.sh x64 release ci -tree:GC -tree:JIT -tree:baseservices -tree:interop -tree:reflection
+
+echo
+echo "****************************"
+echo "Unity: Running runtime tests"
+echo "****************************"
+echo
+./src/tests/build.sh x64 release ci -tree:GC -tree:baseservices -tree:interop -tree:reflection
 ./src/tests/run.sh x64 release
+
+echo
+echo "************************"
+echo "Unity: Running PAL tests"
+echo "************************"
+echo
 ./build.sh clr.paltests
 ./artifacts/bin/coreclr/$(uname).x64.Debug/paltests/runpaltests.sh $(pwd)/artifacts/bin/coreclr/$(uname).x64.Debug/paltests
+
+echo
+echo "**********************************"
+echo "Unity: Tested CoreCLR successfully"
+echo "**********************************"

--- a/.yamato/scripts/test_osx_arm64.sh
+++ b/.yamato/scripts/test_osx_arm64.sh
@@ -1,13 +1,52 @@
-dotnet build unity/managed.sln -c Release
+#!/bin/sh
+set -e
+
+echo "*****************************"
+echo "Unity: Starting CoreCLR tests"
+echo "*****************************"
+
+echo
+echo "******************************"
+echo "Unity: Building embedding host"
+echo "******************************"
+echo
+./dotnet.sh build unity/managed.sln -c Release
+
+echo
+echo "**********************************"
+echo "Unity: Running embedding API tests"
+echo "**********************************"
+echo
 cd unity/embed_api_tests
 cmake -DCMAKE_BUILD_TYPE=Release .
 cmake --build .
 ./mono_test_app
 cd ../../
-# run a small set of library test to ensure basic behavior
+
+echo
+echo "**********************************"
+echo "Unity: Running class library tests"
+echo "**********************************"
+echo
 LD_LIBRARY_PATH=/usr/local/opt/openssl/lib ./build.sh -subset libs.tests -test /p:RunSmokeTestsOnly=true -a arm64 -c release -ci -ninja
-# run five sub-trees of core runtime tests
-./src/tests/build.sh arm64 release ci -tree:GC -tree:JIT -tree:baseservices -tree:interop -tree:reflection
+
+echo
+echo "****************************"
+echo "Unity: Running runtime tests"
+echo "****************************"
+echo
+./src/tests/build.sh arm64 release ci -tree:GC -tree:baseservices -tree:interop -tree:reflection
 ./src/tests/run.sh arm64 release
+
+echo
+echo "************************"
+echo "Unity: Running PAL tests"
+echo "************************"
+echo
 ./build.sh clr.paltests
 ./artifacts/bin/coreclr/OSX.arm64.Debug/paltests/runpaltests.sh $(pwd)/artifacts/bin/coreclr/OSX.arm64.Debug/paltests
+
+echo
+echo "**********************************"
+echo "Unity: Tested CoreCLR successfully"
+echo "**********************************"

--- a/.yamato/scripts/test_osx_x64.sh
+++ b/.yamato/scripts/test_osx_x64.sh
@@ -1,13 +1,52 @@
-dotnet build unity/managed.sln -c Release
+#!/bin/sh
+set -e
+
+echo "*****************************"
+echo "Unity: Starting CoreCLR tests"
+echo "*****************************"
+
+echo
+echo "******************************"
+echo "Unity: Building embedding host"
+echo "******************************"
+echo
+./dotnet.sh build unity/managed.sln -c Release
+
+echo
+echo "**********************************"
+echo "Unity: Running embedding API tests"
+echo "**********************************"
+echo
 cd unity/embed_api_tests
 cmake -DCMAKE_BUILD_TYPE=Release .
 cmake --build .
 ./mono_test_app
 cd ../../
-# run a small set of library test to ensure basic behavior
+
+echo
+echo "**********************************"
+echo "Unity: Running class library tests"
+echo "**********************************"
+echo
 LD_LIBRARY_PATH=/usr/local/opt/openssl/lib ./build.sh -subset libs.tests -test /p:RunSmokeTestsOnly=true -a x64 -c release -ci -ninja
-# run five sub-trees of core runtime tests
-./src/tests/build.sh x64 release ci -tree:GC -tree:JIT -tree:baseservices -tree:interop -tree:reflection
+
+echo
+echo "****************************"
+echo "Unity: Running runtime tests"
+echo "****************************"
+echo
+./src/tests/build.sh x64 release ci -tree:GC -tree:baseservices -tree:interop -tree:reflection
 ./src/tests/run.sh x64 release
+
+echo
+echo "************************"
+echo "Unity: Running PAL tests"
+echo "************************"
+echo
 ./build.sh clr.paltests
 ./artifacts/bin/coreclr/OSX.x64.Debug/paltests/runpaltests.sh $(pwd)/artifacts/bin/coreclr/OSX.x64.Debug/paltests
+
+echo
+echo "**********************************"
+echo "Unity: Tested CoreCLR successfully"
+echo "**********************************"

--- a/.yamato/scripts/test_windows_x64.cmd
+++ b/.yamato/scripts/test_windows_x64.cmd
@@ -1,12 +1,53 @@
-rem build/run tests
-cmd /c dotnet build unity\managed.sln -c Release
-cd unity\embed_api_tests
-cmake .
-cmake --build . --config Release
-Release\mono_test_app.exe
-cd ../../
-rem run a small set of library test to ensure basic behavior
-cmd /c build.cmd libs.tests -test /p:RunSmokeTestsOnly=true -a x64 -c release -ci
-rem run five sub-trees of core runtime tests
-cmd /c src\tests\build.cmd x64 release ci tree GC tree JIT tree baseservices tree interop tree reflection
-cmd /c src\tests\run.cmd x64 release
+@echo off
+
+echo *****************************
+echo Unity: Starting CoreCLR tests
+echo *****************************
+
+echo.
+echo ******************************
+echo Unity: Building embedding host
+echo ******************************
+echo.
+cmd /c dotnet build unity\managed.sln -c Release || goto :error
+
+echo.
+echo **********************************
+echo Unity: Running embedding API tests
+echo **********************************
+echo.
+cd unity\embed_api_tests || goto :error
+cmake . || goto :error
+cmake --build . --config Release || goto :error
+Release\mono_test_app.exe || goto :error
+cd ../../ || goto :error
+
+echo.
+echo **********************************
+echo Unity: Running class library tests
+echo **********************************
+echo.
+cmd /c build.cmd libs.tests -test /p:RunSmokeTestsOnly=true -a x64 -c release -ci || goto :error
+
+echo.
+echo ****************************
+echo Unity: Running runtime tests
+echo ****************************
+echo.
+cmd /c src\tests\build.cmd x64 release ci tree GC tree baseservices tree interop tree reflection || goto :error
+cmd /c src\tests\run.cmd x64 release || goto :error
+
+rem Every thing succeeded - jump to the end of the file and return a 0 exit code
+echo.
+echo **********************************
+echo Unity: Tested CoreCLR successfully
+echo **********************************
+goto :EOF
+
+rem If we get here, one of the commands above failed
+:error
+echo.
+echo ***************************
+echo Unity: CoreCLR tests failed
+echo ***************************
+exit /b %errorlevel%

--- a/.yamato/scripts/test_windows_x86.cmd
+++ b/.yamato/scripts/test_windows_x86.cmd
@@ -1,13 +1,52 @@
-rem build/run tests
-cmd /c dotnet build unity\managed.sln -c Release
-rem  - |
-rem    cd unity\embed_api_tests
-rem    cmake . -A Win32
-rem    cmake --build . --config Release
-rem    Release\mono_test_app.exe
+@echo off
 
-rem run a small set of library test to ensure basic behavior
-cmd /c build.cmd libs.tests -test /p:RunSmokeTestsOnly=true -a x86 -c release -ci
-rem run five sub-trees of core runtime tests
-cmd /c src\tests\build.cmd x86 release ci tree GC tree JIT tree baseservices tree interop tree reflection
-cmd /c src\tests\run.cmd x86 release
+echo *****************************
+echo Unity: Starting CoreCLR tests
+echo *****************************
+
+echo.
+echo ******************************
+echo Unity: Building embedding host
+echo ******************************
+echo.
+cmd /c dotnet build unity\managed.sln -c Release || goto :error
+
+echo.
+echo *****************************************************
+echo Unity: Skipping embedding API tests on 32-bit Windows
+echo *****************************************************
+echo.
+rem    cd unity\embed_api_tests || goto :error
+rem    cmake . -A Win32 || goto :error
+rem    cmake --build . --config Release || goto :error
+rem    Release\mono_test_app.exe || goto :error
+
+echo.
+echo **********************************
+echo Unity: Running class library tests
+echo **********************************
+echo.
+cmd /c build.cmd libs.tests -test /p:RunSmokeTestsOnly=true -a x86 -c release -ci || goto :error
+
+echo.
+echo ****************************
+echo Unity: Running runtime tests
+echo ****************************
+echo.
+cmd /c src\tests\build.cmd x86 release ci tree GC tree baseservices tree interop tree reflection || goto :error
+cmd /c src\tests\run.cmd x86 release || goto :error
+
+rem Every thing succeeded - jump to the end of the file and return a 0 exit code
+echo.
+echo **********************************
+echo Unity: Tested CoreCLR successfully
+echo **********************************
+goto :EOF
+
+rem If we get here, one of the commands above failed
+:error
+echo.
+echo ***************************
+echo Unity: CoreCLR tests failed
+echo ***************************
+exit /b %errorlevel%

--- a/.yamato/test_windows_x64.yml
+++ b/.yamato/test_windows_x64.yml
@@ -4,7 +4,7 @@ name: Test Windows x64
 
 agent:
   type: Unity::VM
-  image: platform-foundation/windows-vs2019-il2cpp-bokken:v1.1.7-1038262
+  image: burst/burst-base:1.0.8-1195360
   flavor: b1.xlarge
 
 dependencies:
@@ -13,7 +13,7 @@ dependencies:
 commands:
 # build/run tests
   - .yamato/scripts/test_windows_x64.cmd
-  
+
 triggers:
   pull_requests:
     - targets:

--- a/.yamato/test_windows_x86.yml
+++ b/.yamato/test_windows_x86.yml
@@ -4,7 +4,7 @@ name: Test Windows x86
 
 agent:
   type: Unity::VM
-  image: platform-foundation/windows-vs2019-il2cpp-bokken:v1.1.7-1038262
+  image: burst/burst-base:1.0.8-1195360
   flavor: b1.xlarge
 
 dependencies:


### PR DESCRIPTION
These changes use a Bokken image with Visual Studio 2022 installed. They also add logging to the test script and ensure that that will exit when the tests or builds fail.