### PR TITLE
A few minor fixes:

### DIFF
--- a/unity/embed_api_tests/main.cpp
+++ b/unity/embed_api_tests/main.cpp
@@ -1176,7 +1176,6 @@ TEST(can_call_method_on_member_struct)
     CHECK_EQUAL(579, int_result);
 }
 
-#if FAILING_TEST
 
 TEST(can_call_interface_method_on_member_struct)
 {
@@ -1201,7 +1200,6 @@ TEST(can_call_interface_method_on_member_struct)
     int int_result = *(int*)mono_object_unbox(returnValue);
     CHECK_EQUAL(42, int_result);
 }
-#endif
 
 TEST(mono_object_get_virtual_method_can_call_interface_method_on_struct)
 {
@@ -1218,7 +1216,6 @@ TEST(mono_object_get_virtual_method_can_call_interface_method_on_struct)
     CHECK_EQUAL(42, int_result);
 }
 
-#if FAILING_TEST
 
 // the call to mono_object_get_virtual_method cannot properly lookup explicit interface imlpementations
 
@@ -1237,7 +1234,6 @@ TEST(mono_object_get_virtual_method_can_call_explicit_interface_method_on_struct
     CHECK_EQUAL(42, int_result);
 }
 
-#endif
 
 TEST(mono_type_is_byref_works)
 {

--- a/unity/unity-sources/Runtime/Mono/MonoFunctions.h
+++ b/unity/unity-sources/Runtime/Mono/MonoFunctions.h
@@ -344,7 +344,11 @@ DO_API(void, mono_dl_fallback_unregister, (MonoDlFallbackHandler * handler))
 
 #endif
 
-typedef UNUSED_SYMBOL void(*vprintf_func)(const char* msg, va_list args);
+#ifdef WIN32
+typedef int (__cdecl *vprintf_func)(const char* msg, va_list args);
+#else
+typedef int (*vprintf_func)(const char* msg, va_list args);
+#endif
 DO_API(void, mono_unity_set_vprintf_func, (vprintf_func func))
 
 DO_API(void*, mono_unity_liveness_allocate_struct, (MonoClass * filter, int max_object_count, mono_register_object_callback callback, void* userdata, mono_liveness_reallocate_callback reallocate))


### PR DESCRIPTION
* Fixed issue where explicitly implemented interface methods would not be found.
* Added ability to call function `unity_log` in mono_coreclr.cpp to successfully log to the unity stdout.
* Switched several functions to use existing coreclr APIs instead of reimplementing them.