### PR TITLE
Ignore the CMake generated projects for the Embedding API tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -366,3 +366,8 @@ src/coreclr/System.Private.CoreLib/common
 # Temporary artifacts from local libraries stress builds
 .dotnet-daily/
 run-stress-*
+
+# Unity emebdding API tests
+unity/embed_api_tests/ALL_BUILD.*
+unity/embed_api_tests/ZERO_CHECK.*
+unity/embed_api_tests/mono_test_app.*


### PR DESCRIPTION
These projects are generated during a normal build and test run locally. We never want to commit them, so make sure they are ignored.