### PR TITLE
Cherry-pick macOS build fixes from upstream

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
@@ -1474,7 +1474,7 @@ namespace Internal.TypeSystem.Interop
             get
             {
                 return MarshalDirection == MarshalDirection.Forward
-                    && MarshallerType != MarshallerType.Field
+                    && MarshallerType == MarshallerType.Argument
                     && !IsManagedByRef
                     && In
                     && !Out;
@@ -1672,7 +1672,11 @@ namespace Internal.TypeSystem.Interop
         {
             ILEmitter emitter = _ilCodeStreams.Emitter;
 
-            if (In && !Out && !IsManagedByRef)
+            if (MarshalDirection == MarshalDirection.Forward
+                && MarshallerType == MarshallerType.Argument
+                && !IsManagedByRef
+                && In
+                && !Out)
             {
                 TypeDesc marshallerIn = MarshallerIn;
 

--- a/src/native/libs/System.Security.Cryptography.Native.Apple/pal_keychain_macos.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/pal_keychain_macos.c
@@ -16,7 +16,10 @@ int32_t AppleCryptoNative_SecKeychainItemCopyKeychain(SecKeychainItemRef item, S
 
     if (itemType == SecKeyGetTypeID() || itemType == SecIdentityGetTypeID() || itemType == SecCertificateGetTypeID())
     {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         OSStatus status = SecKeychainItemCopyKeychain(item, pKeychainOut);
+#pragma clang diagnostic pop
 
         if (status == noErr)
         {
@@ -40,12 +43,18 @@ int32_t AppleCryptoNative_SecKeychainCreate(const char* pathName,
                                             const uint8_t* passphraseUtf8,
                                             SecKeychainRef* pKeychainOut)
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     return SecKeychainCreate(pathName, passphraseLength, passphraseUtf8, false, NULL, pKeychainOut);
+#pragma clang diagnostic pop
 }
 
 int32_t AppleCryptoNative_SecKeychainDelete(SecKeychainRef keychain)
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     return SecKeychainDelete(keychain);
+#pragma clang diagnostic pop
 }
 
 int32_t AppleCryptoNative_SecKeychainCopyDefault(SecKeychainRef* pKeychainOut)
@@ -53,7 +62,10 @@ int32_t AppleCryptoNative_SecKeychainCopyDefault(SecKeychainRef* pKeychainOut)
     if (pKeychainOut != NULL)
         *pKeychainOut = NULL;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     return SecKeychainCopyDefault(pKeychainOut);
+#pragma clang diagnostic pop
 }
 
 int32_t AppleCryptoNative_SecKeychainOpen(const char* pszKeychainPath, SecKeychainRef* pKeychainOut)
@@ -64,12 +76,18 @@ int32_t AppleCryptoNative_SecKeychainOpen(const char* pszKeychainPath, SecKeycha
     if (pszKeychainPath == NULL)
         return errSecParam;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     return SecKeychainOpen(pszKeychainPath, pKeychainOut);
+#pragma clang diagnostic pop
 }
 
 int32_t AppleCryptoNative_SecKeychainUnlock(SecKeychainRef keychain, uint32_t passphraseLength, const uint8_t* passphraseUtf8)
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     return SecKeychainUnlock(keychain, passphraseLength, passphraseUtf8, true);
+#pragma clang diagnostic pop
 }
 
 int32_t AppleCryptoNative_SetKeychainNeverLock(SecKeychainRef keychain)
@@ -81,7 +99,10 @@ int32_t AppleCryptoNative_SetKeychainNeverLock(SecKeychainRef keychain)
         .lockInterval = INT_MAX,
     };
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     return SecKeychainSetSettings(keychain, &settings);
+#pragma clang diagnostic pop
 }
 
 static int32_t
@@ -262,7 +283,7 @@ static bool IsCertInKeychain(CFTypeRef needle, SecKeychainRef haystack)
     {
         ret = false;
     }
-    
+
     if (result != NULL)
     {
         CFRelease(result);
@@ -355,7 +376,10 @@ int32_t AppleCryptoNative_X509StoreAddCertificate(CFTypeRef certOrIdentity, SecK
     // keychain back to disk.
     if (status == noErr && privateKey != NULL)
     {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         status = SecKeychainItemCreateCopy((SecKeychainItemRef)privateKey, keychain, NULL, &itemCopy);
+#pragma clang diagnostic pop
     }
 
     if (status == errSecDuplicateItem)
@@ -374,7 +398,10 @@ int32_t AppleCryptoNative_X509StoreAddCertificate(CFTypeRef certOrIdentity, SecK
 
     if (status == noErr && cert != NULL)
     {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         status = SecKeychainItemCreateCopy((SecKeychainItemRef)cert, keychain, NULL, &itemCopy);
+#pragma clang diagnostic pop
     }
 
     if (status == errSecDuplicateItem)

--- a/src/native/libs/System.Security.Cryptography.Native.Apple/pal_x509_macos.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/pal_x509_macos.c
@@ -384,8 +384,10 @@ int32_t AppleCryptoNative_X509CopyWithPrivateKey(SecCertificateRef cert,
     }
 
     SecKeychainRef keyKeychain = NULL;
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     OSStatus status = SecKeychainItemCopyKeychain((SecKeychainItemRef)privateKey, &keyKeychain);
+#pragma clang diagnostic pop
     SecKeychainItemRef itemCopy = NULL;
 
     // This only happens with an ephemeral key, so the keychain we're adding it to is temporary.
@@ -536,7 +538,10 @@ int32_t AppleCryptoNative_X509MoveToKeychain(SecCertificateRef cert,
 
     SecKeychainRef curKeychain = NULL;
     SecKeyRef importedKey = NULL;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     OSStatus status = SecKeychainItemCopyKeychain((SecKeychainItemRef)cert, &curKeychain);
+#pragma clang diagnostic pop
 
     if (status == errSecNoSuchKeychain)
     {
@@ -559,7 +564,10 @@ int32_t AppleCryptoNative_X509MoveToKeychain(SecCertificateRef cert,
 
     if (status == noErr && privateKey != NULL)
     {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         status = SecKeychainItemCopyKeychain((SecKeychainItemRef)privateKey, &curKeychain);
+#pragma clang diagnostic pop
 
         if (status == errSecNoSuchKeychain)
         {

--- a/src/tests/Common/Platform/platformdefines.cpp
+++ b/src/tests/Common/Platform/platformdefines.cpp
@@ -170,8 +170,9 @@ error_t TP_putenv_s(LPWSTR name, LPWSTR value)
         return 0;
 #else
     int retVal = 0;
-    char *assignment = (char*) malloc(sizeof(char) * (TP_slen(name) + TP_slen(value) + 1));
-    sprintf(assignment, "%s=%s", HackyConvertToSTR(name), HackyConvertToSTR(value));
+    size_t assignmentSize = sizeof(char) * (TP_slen(name) + TP_slen(value) + 1 + 1);
+    char *assignment = (char*) malloc(assignmentSize);
+    snprintf(assignment, assignmentSize, "%s=%s", HackyConvertToSTR(name), HackyConvertToSTR(value));
 
     if (0 != putenv(assignment))
         retVal = 2;

--- a/src/tests/nativeaot/SmokeTests/PInvoke/PInvoke.cs
+++ b/src/tests/nativeaot/SmokeTests/PInvoke/PInvoke.cs
@@ -702,6 +702,8 @@ namespace PInvokeTests
             public float f2;
             [MarshalAs(UnmanagedType.LPStr)]
             public String f3;
+            [MarshalAs(UnmanagedType.LPUTF8Str)]
+            public String f4;
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -713,6 +715,8 @@ namespace PInvokeTests
             public float f2;
             [MarshalAs(UnmanagedType.LPStr)]
             public String f3;
+            [MarshalAs(UnmanagedType.LPUTF8Str)]
+            public String f4;
         }
 
         // A second struct with the same name but nested. Regression test against native types being mangled into
@@ -824,15 +828,16 @@ namespace PInvokeTests
             ss.f1 = 1;
             ss.f2 = 10.0f;
             ss.f3 = "Hello";
+            ss.f4 = "Hola";
 
             ThrowIfNotEquals(true, StructTest(ss), "Struct marshalling scenario1 failed.");
 
             StructTest_ByRef(ref ss);
-            ThrowIfNotEquals(true,  ss.f1 == 2 && ss.f2 == 11.0 && ss.f3.Equals("Ifmmp"), "Struct marshalling scenario2 failed.");
+            ThrowIfNotEquals(true,  ss.f1 == 2 && ss.f2 == 11.0 && ss.f3.Equals("Ifmmp") && ss.f4.Equals("Ipmb"), "Struct marshalling scenario2 failed.");
 
             SequentialStruct ss2 = new SequentialStruct();
             StructTest_ByOut(out ss2);
-            ThrowIfNotEquals(true, ss2.f0 == 1 && ss2.f1 == 1.0 &&  ss2.f2 == 1.0 && ss2.f3.Equals("0123456"), "Struct marshalling scenario3 failed.");
+            ThrowIfNotEquals(true, ss2.f0 == 1 && ss2.f1 == 1.0 &&  ss2.f2 == 1.0 && ss2.f3.Equals("0123456") && ss2.f4.Equals("789"), "Struct marshalling scenario3 failed.");
 
             NesterOfSequentialStruct.SequentialStruct ss3 = new NesterOfSequentialStruct.SequentialStruct();
             ss3.f1 = 10.0f;
@@ -861,6 +866,7 @@ namespace PInvokeTests
                 ssa[i].f1 = i;
                 ssa[i].f2 = i*i;
                 ssa[i].f3 = i.LowLevelToString();
+                ssa[i].f4 = "u8" + i.LowLevelToString();
             }
             ThrowIfNotEquals(true, StructTest_Array(ssa, ssa.Length), "Array of struct marshalling failed");
 
@@ -923,9 +929,10 @@ namespace PInvokeTests
             ss.f1 = 1;
             ss.f2 = 10.0f;
             ss.f3 = "Hello";
+            ss.f4 = "Hola";
 
             ClassTest(ss);
-            ThrowIfNotEquals(true, ss.f1 == 2 && ss.f2 == 11.0 && ss.f3.Equals("Ifmmp"), "LayoutClassPtr marshalling scenario1 failed.");
+            ThrowIfNotEquals(true, ss.f1 == 2 && ss.f2 == 11.0 && ss.f3.Equals("Ifmmp") && ss.f4.Equals("Ipmb"), "LayoutClassPtr marshalling scenario1 failed.");
         }
 
 #if OPTIMIZED_MODE_WITHOUT_SCANNER
@@ -955,20 +962,22 @@ namespace PInvokeTests
             sc.f1 = 1;
             sc.f2 = 10.0f;
             sc.f3 = "Hello";
+            sc.f4 = "Hola";
 
             AsAnyTest(sc);
-            ThrowIfNotEquals(true, sc.f1 == 2 && sc.f2 == 11.0 && sc.f3.Equals("Ifmmp"), "AsAny marshalling scenario1 failed.");
+            ThrowIfNotEquals(true, sc.f1 == 2 && sc.f2 == 11.0 && sc.f3.Equals("Ifmmp") && sc.f4.Equals("Ipmb"), "AsAny marshalling scenario1 failed.");
 
             SequentialStruct ss = new SequentialStruct();
             ss.f0 = 100;
             ss.f1 = 1;
             ss.f2 = 10.0f;
             ss.f3 = "Hello";
+            ss.f4 = "Hola";
 
             object o = ss;
             AsAnyTest(o);
             ss = (SequentialStruct)o;
-            ThrowIfNotEquals(true, ss.f1 == 2 && ss.f2 == 11.0 && ss.f3.Equals("Ifmmp"), "AsAny marshalling scenario2 failed.");
+            ThrowIfNotEquals(true, ss.f1 == 2 && ss.f2 == 11.0 && ss.f3.Equals("Ifmmp") && sc.f4.Equals("Ipmb"), "AsAny marshalling scenario2 failed.");
         }
 
         private static void TestLayoutClass()

--- a/src/tests/nativeaot/SmokeTests/PInvoke/PInvokeNative.cpp
+++ b/src/tests/nativeaot/SmokeTests/PInvoke/PInvokeNative.cpp
@@ -569,12 +569,12 @@ DLL_EXPORT bool __stdcall StructTest_Array(NativeSequentialStruct *nss, int leng
             return false;
         if (nss[i].b != i*i)
             return false;
-        sprintf(expected, "%d", i);
+        snprintf(expected, sizeof(expected), "%d", i);
 
         if (CompareAnsiString(expected, nss[i].str) == 0)
             return false;
 
-        sprintf(expected, "u8%d", i);
+        snprintf(expected, sizeof(expected), "u8%d", i);
 
         if (CompareAnsiString(expected, nss[i].u8str) == 0)
             return false;

--- a/src/tests/nativeaot/SmokeTests/PInvoke/PInvokeNative.cpp
+++ b/src/tests/nativeaot/SmokeTests/PInvoke/PInvokeNative.cpp
@@ -471,6 +471,7 @@ struct NativeSequentialStruct
     int a;
     float b;
     char *str;
+    char *u8str;
 };
 
 struct NativeSequentialStruct2
@@ -492,6 +493,9 @@ DLL_EXPORT bool __stdcall StructTest(NativeSequentialStruct nss)
 
 
     if (!CompareAnsiString(nss.str, "Hello"))
+        return false;
+
+    if (!CompareAnsiString(nss.u8str, "Hola"))
         return false;
 
     return true;
@@ -519,6 +523,13 @@ DLL_EXPORT void __stdcall StructTest_ByRef(NativeSequentialStruct *nss)
         *p = *p + 1;
         p++;
     }
+
+    p = nss->u8str;
+    while (*p != '\0')
+    {
+        *p = *p + 1;
+        p++;
+    }
 }
 
 DLL_EXPORT void __stdcall StructTest_ByOut(NativeSequentialStruct *nss)
@@ -529,7 +540,7 @@ DLL_EXPORT void __stdcall StructTest_ByOut(NativeSequentialStruct *nss)
 
     int arrSize = 7;
     char *p;
-    p = (char *)MemAlloc(sizeof(char) * arrSize);
+    p = (char *)MemAlloc(sizeof(char) * arrSize + 1);
 
     for (int i = 0; i < arrSize; i++)
     {
@@ -537,6 +548,10 @@ DLL_EXPORT void __stdcall StructTest_ByOut(NativeSequentialStruct *nss)
     }
     *(p + arrSize) = '\0';
     nss->str = p;
+
+    p = (char *)MemAlloc(sizeof(char) * 4);
+    strcpy(p, "789");
+    nss->u8str = p;
 }
 
 DLL_EXPORT bool __stdcall StructTest_Array(NativeSequentialStruct *nss, int length)
@@ -557,6 +572,11 @@ DLL_EXPORT bool __stdcall StructTest_Array(NativeSequentialStruct *nss, int leng
         sprintf(expected, "%d", i);
 
         if (CompareAnsiString(expected, nss[i].str) == 0)
+            return false;
+
+        sprintf(expected, "u8%d", i);
+
+        if (CompareAnsiString(expected, nss[i].u8str) == 0)
             return false;
     }
     return true;


### PR DESCRIPTION
These three changes are required to work around build failures on newer macOS and Xcode versions. They have been cleanly cherry-picked from upstream.

We don't need them to build on CI, as our CI images use older enough versions of macOS and Xcode. But to build locally I do need them. Do we want to take these change specifically? Or should we instead try to get a normal sync from upstream to pick them up?