### PR TITLE
Run embedding API tests on Linux

### DIFF
--- a/.yamato/scripts/test_linux.sh
+++ b/.yamato/scripts/test_linux.sh
@@ -27,14 +27,14 @@ echo
 
 echo
 echo "***********************************"
-echo "Unity: Skipping embedding API tests"
+echo "Unity: Running embedding API tests"
 echo "***********************************"
 echo
-# cd unity/embed_api_tests
-# cmake -DCMAKE_BUILD_TYPE=$configuration .
-# cmake --build .
-# ./mono_test_app
-# cd ../../
+cd unity/embed_api_tests
+cmake -DCMAKE_BUILD_TYPE=$configuration .
+cmake --build .
+./mono_test_app
+cd ../../
 
 echo
 echo "**********************************"

--- a/unity/embed_api_tests/CMakeLists.txt
+++ b/unity/embed_api_tests/CMakeLists.txt
@@ -10,5 +10,8 @@ include_directories(${CLR_DIR}/src/inc)
 
 add_executable(${PROJECT_NAME_STR} ${PROJECT_SRC_FILES})
 target_link_libraries(${PROJECT_NAME_STR} ${CMAKE_DL_LIBS})
+if(UNIX AND NOT APPLE)
+    target_link_libraries(${PROJECT_NAME_STR} pthread)
+endif()
 target_compile_features(${PROJECT_NAME_STR} PRIVATE cxx_range_for)
 target_compile_definitions(${PROJECT_NAME_STR} PRIVATE ENABLE_MONO=1 PLATFORM_STANDALONE=1)

--- a/unity/embed_api_tests/main.cpp
+++ b/unity/embed_api_tests/main.cpp
@@ -18,10 +18,10 @@
 #define UNITY_EDITOR 1
 #define USE_CORECLR
 
-// On macOS the compiler does not define _DEBUG, but CMake defines
+// On macOS and Linux the compiler does not define _DEBUG, but CMake defines
 // NDEBUG for release builds, so if NDEBUG is not defined, assume this
 // is a debug build and define _DEBUG.
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(__linux__)
 #ifndef NDEBUG
 #define _DEBUG
 #endif
@@ -89,6 +89,7 @@ void* get_handle()
         if(s_MonoLibrary == nullptr)
         {
             assert(false && "Failed to load mono\n");
+            printf("Failed to load mono from '%s'\n", g_monoDllPath.c_str());
             exit(1);
         }
     }
@@ -2439,8 +2440,13 @@ void SetupMono(Mode mode)
 #endif // __aarch64__
 #endif
 #elif defined(__linux__)
-        monoLibFolder = "/usr/share/dotnet/shared/Microsoft.NETCore.App/3.1.0";
-        g_monoDllPath = "../../bin/Product/Linux.x64.Debug/libcoreclr.so";
+#if defined(_DEBUG)
+        monoLibFolder = abs_path_from_file("../../artifacts/bin/microsoft.netcore.app.runtime.linux-x64/Debug/runtimes/linux-x64/lib/net7.0");
+        g_monoDllPath = abs_path_from_file("../../artifacts/bin/microsoft.netcore.app.runtime.linux-x64/Debug/runtimes/linux-x64/native/libcoreclr.so");
+#else
+        monoLibFolder = abs_path_from_file("../../artifacts/bin/microsoft.netcore.app.runtime.linux-x64/Release/runtimes/linux-x64/lib/net7.0");
+        g_monoDllPath = abs_path_from_file("../../artifacts/bin/microsoft.netcore.app.runtime.linux-x64/Release/runtimes/linux-x64/native/libcoreclr.so");
+#endif
 #elif defined(WIN32)
 #if defined(_DEBUG)
 #ifdef _M_AMD64


### PR DESCRIPTION
With this change, we link pthreads properly in the embedding API tests on Linux, locate the CoreCLR runtime properly, and run the tests on CI.