### PR TITLE
Add "CoreCLR" to the name of the all tests configuration on CI.

### DIFF
--- a/.yamato/all_tests.yml
+++ b/.yamato/all_tests.yml
@@ -1,5 +1,5 @@
 all:
-  name: All Tests
+  name: All CoreCLR Tests
   dependencies:
   - path: .yamato/windows.yml#all
   - path: .yamato/osx.yml#all


### PR DESCRIPTION
This helps to identify this test run in email and Slack notifications, where it is sent without much context.