### PR TITLE
Make changes to allow Unity runtime tests on macOS to work

### DIFF
--- a/src/coreclr/vm/mono/mono_coreclr.cpp
+++ b/src/coreclr/vm/mono/mono_coreclr.cpp
@@ -2870,7 +2870,7 @@ extern "C" EXPORT_API void EXPORT_CC mono_set_break_policy(MonoBreakPolicyFunc p
 
 extern "C" EXPORT_API void EXPORT_CC mono_set_crash_chaining (gboolean)
 {
-    ASSERT_NOT_IMPLEMENTED;
+    // NOP
 }
 
 extern "C" EXPORT_API void EXPORT_CC mono_set_defaults(int verbose_level, guint32 opts)
@@ -3300,7 +3300,8 @@ extern "C" EXPORT_API void EXPORT_CC mono_unity_assembly_mempool_chunk_foreach (
 #if defined(HOST_OSX) || defined(HOST_UNIX)
 extern "C" EXPORT_API int EXPORT_CC mono_unity_backtrace_from_context(void* context, void* array[], int count)
 {
-    ASSERT_NOT_IMPLEMENTED;
+    // Not implemented yet. Returning no frames allows code to continue without
+    // stack trace support.
     return 0;
 }
 #endif

--- a/unity/README.md
+++ b/unity/README.md
@@ -47,7 +47,7 @@ Windows:
 
 macOS:
 ```
-> cp -r artifacts/bin/microsoft.netcore.app.runtime.osx-x64/Debug/runtimes/osx-x64/* <Unity player build directory>/Contents/Resources/Data/CoreCLR
+> cp -r artifacts/bin/microsoft.netcore.app.runtime.osx-<your arch>/Debug/runtimes/osx-<your arch>/* <Unity player build directory>/Contents/Resources/Data/CoreCLR
 ```
 
 **Caveat:** It is _not_ possible to enable mixed mode debugging in Visual Studio and also debug the native code in coreclr.dll. Visual Studio blocks this workflow to prevent hangs. To debug in coreclr.dll in a Unity player, Native debugging must be selected in Visual Studio.

--- a/unity/README.md
+++ b/unity/README.md
@@ -38,10 +38,16 @@ unity/test-scripts/build_test_windows.cmd x64 Debug
 
 ### Using a debug build of the CoreCLR runtime in Unity
 
-Once the CoreCLR runtime has been built locally you can find the runtime artfacts the Unity player needs in `artifacts\bin\microsoft.netcore.app.runtime.win-x64\Debug\runtimes\win-x64`. Replace `Debug` with `Release` in this path for the Release configuration. It is important to copy all of the runtime and class library files together, as they need to stay in sync in order for the CoreCLR runtime to work properly. On Windows, the recursive directory copy (overwriting files in the destination) looks like this:
+Once the CoreCLR runtime has been built locally you can find the runtime artifacts the Unity player needs in `artifacts\bin\microsoft.netcore.app.runtime.win-x64\Debug\runtimes\win-x64`. Replace `Debug` with `Release` in this path for the Release configuration. It is important to copy all of the runtime and class library files together, as they need to stay in sync in order for the CoreCLR runtime to work properly. On Windows, the recursive directory copy (overwriting files in the destination) looks like this:
 
+Windows:
 ```
 > xcopy /e /y artifacts\bin\microsoft.netcore.app.runtime.win-x64\Debug\runtimes\win-x64 <Unity player build directory>\CoreCLR
+```
+
+macOS:
+```
+> cp -r artifacts/bin/microsoft.netcore.app.runtime.osx-x64/Debug/runtimes/osx-x64/* <Unity player build directory>/Contents/Resources/Data/CoreCLR
 ```
 
 **Caveat:** It is _not_ possible to enable mixed mode debugging in Visual Studio and also debug the native code in coreclr.dll. Visual Studio blocks this workflow to prevent hangs. To debug in coreclr.dll in a Unity player, Native debugging must be selected in Visual Studio.


### PR DESCRIPTION
These changes help with using CoreCLR in Unity on macOS, and allow Unity's runtime tests to pass on macOS.