### PR TITLE
Increase the size of MonoInternalCallFrameOpaque

### DIFF
--- a/src/coreclr/vm/mono/mono_coreclr.cpp
+++ b/src/coreclr/vm/mono/mono_coreclr.cpp
@@ -1543,7 +1543,8 @@ struct MonoInternalCallFrame
     bool didSetupFrame;
 };
 
-//static_assert(sizeof(MonoInternalCallFrame) <= sizeof(MonoInternalCallFrameOpaque), "MonoInternalCallFrameOpaque needs to be larger");
+// If this fails the size of MonoInternalCallFrameOpaque needs to be updted in MonoTypes.h in this repo and the Unity repo.
+static_assert(sizeof(MonoInternalCallFrame) <= sizeof(MonoInternalCallFrameOpaque), "MonoInternalCallFrameOpaque needs to be larger");
 
 // We currently need to wrap Unity icalls called from managed code mono_enter/exit_internal_call.
 // This has two reasons:

--- a/unity/unity-sources/Runtime/Mono/MonoTypes.h
+++ b/unity/unity-sources/Runtime/Mono/MonoTypes.h
@@ -63,9 +63,9 @@ struct MonoString
 
 struct MonoInternalCallFrameOpaque
 {
-    // in release builds, this is only 248 bytes - but it does not matter if we make it
+    // in release builds, this is only 280 bytes (macOS arm64) - but it does not matter if we make it
     // larger, that just means some extra unused bytes on the stack.
-    char data[256]; // Debug
+    char data[290]; // Debug
 };
 
 struct MonoMethod


### PR DESCRIPTION
and enable a comile check to ensure that we make adjustments to the size if needed.