### PR TITLE
add fix of Catch for macOS on ARM

### DIFF
--- a/unity/embed_api_tests/catch/catch.hpp
+++ b/unity/embed_api_tests/catch/catch.hpp
@@ -2130,7 +2130,13 @@ namespace Catch{
                 __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n" \
                 : : : "memory","r0","r3","r4" ) /* NOLINT */
     #else
-        #define CATCH_TRAP() __asm__("int $3\n" : : /* NOLINT */ )
+        // The following code snippet based on:
+        // https://github.com/catchorg/Catch2/commit/a25c1a24af8bffd35727a888a307ff0280cf9387
+        #if defined(__i386__) || defined(__x86_64__)
+            #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
+        #elif defined(__aarch64__)
+            #define CATCH_TRAP()  __asm__(".inst 0xd4200000")
+        #endif
     #endif
 
 #elif defined(CATCH_PLATFORM_LINUX)


### PR DESCRIPTION
The current Cmake command will fail on Mac M1 Max with the error coming from catch:
```
runtime/unity/embed_api_tests/main.cpp:279:5: error: unrecognized instruction mnemonic, did you mean: bit, cnt, hint, ins, not?
    CHECK(strcmp(methodname, mono_method_get_name(method)) == 0);
```

This change will fix it, providing supports for ARM.

Referenced from a check2 fix: https://github.com/catchorg/Catch2/commit/a25c1a24af8bffd35727a888a307ff0280cf9387