### PR TITLE
Target net7.0 and isolate unity projects.

### DIFF
--- a/.yamato/scripts/build_linux.sh
+++ b/.yamato/scripts/build_linux.sh
@@ -59,8 +59,8 @@ echo "Unity: Copying built artifacts"
 echo "*******************************"
 echo
 cp unity/unitygc/$configuration/libunitygc.so artifacts/bin/microsoft.netcore.app.runtime.linux-x64/$configuration/runtimes/linux-x64/native
-cp artifacts/bin/unity-embed-host/$configuration/net6.0/unity-embed-host.dll artifacts/bin/microsoft.netcore.app.runtime.linux-x64/$configuration/runtimes/linux-x64/lib/net7.0
-cp artifacts/bin/unity-embed-host/$configuration/net6.0/unity-embed-host.dll artifacts/bin/microsoft.netcore.app.runtime.linux-x64/$configuration/runtimes/linux-x64/lib/net7.0
+cp unity/unity-embed-host/bin/$configuration/net7.0/unity-embed-host.dll artifacts/bin/microsoft.netcore.app.runtime.linux-x64/$configuration/runtimes/linux-x64/lib/net7.0
+cp unity/unity-embed-host/bin/$configuration/net7.0/unity-embed-host.dll artifacts/bin/microsoft.netcore.app.runtime.linux-x64/$configuration/runtimes/linux-x64/lib/net7.0
 cp LICENSE.md artifacts/bin/microsoft.netcore.app.runtime.linux-x64/$configuration/runtimes/linux-x64/.
 artifacts/7za-linux-x64/7za a artifacts/unity/$ARTIFACT_FILENAME ./artifacts/bin/microsoft.netcore.app.runtime.linux-x64/$configuration/runtimes/linux-x64/*
 

--- a/.yamato/scripts/build_osx.sh
+++ b/.yamato/scripts/build_osx.sh
@@ -84,8 +84,8 @@ echo "Unity: Copying built artifacts"
 echo "*******************************"
 echo
 cp unity/unitygc/$configuration/libunitygc.dylib artifacts/bin/microsoft.netcore.app.runtime.osx-$architecture/$configuration/runtimes/osx-$architecture/native
-cp artifacts/bin/unity-embed-host/$configuration/net6.0/unity-embed-host.dll artifacts/bin/microsoft.netcore.app.runtime.osx-$architecture/$configuration/runtimes/osx-$architecture/lib/net7.0
-cp artifacts/bin/unity-embed-host/$configuration/net6.0/unity-embed-host.pdb artifacts/bin/microsoft.netcore.app.runtime.osx-$architecture/$configuration/runtimes/osx-$architecture/lib/net7.0
+cp unity/unity-embed-host/bin/$configuration/net7.0/unity-embed-host.dll artifacts/bin/microsoft.netcore.app.runtime.osx-$architecture/$configuration/runtimes/osx-$architecture/lib/net7.0
+cp unity/unity-embed-host/bin/$configuration/net7.0/unity-embed-host.pdb artifacts/bin/microsoft.netcore.app.runtime.osx-$architecture/$configuration/runtimes/osx-$architecture/lib/net7.0
 cp LICENSE.md artifacts/bin/microsoft.netcore.app.runtime.osx-$architecture/$configuration/runtimes/osx-$architecture/.
 artifacts/7za-mac-x64/7za a artifacts/unity/$ARTIFACT_FILENAME ./artifacts/bin/microsoft.netcore.app.runtime.osx-$architecture/$configuration/runtimes/osx-$architecture/*
 

--- a/.yamato/scripts/build_windows.cmd
+++ b/.yamato/scripts/build_windows.cmd
@@ -60,8 +60,8 @@ echo Unity: Copying built artifacts
 echo ******************************
 echo.
 copy unity\unitygc\%configuration%\unitygc.dll artifacts\bin\microsoft.netcore.app.runtime.win-%architecture%\%configuration%\runtimes\win-%architecture%\native || goto :error
-copy artifacts\bin\unity-embed-host\%configuration%\net6.0\unity-embed-host.dll artifacts\bin\microsoft.netcore.app.runtime.win-%architecture%\%configuration%\runtimes\win-%architecture%\lib\net7.0 || goto :error
-copy artifacts\bin\unity-embed-host\%configuration%\net6.0\unity-embed-host.pdb artifacts\bin\microsoft.netcore.app.runtime.win-%architecture%\%configuration%\runtimes\win-%architecture%\lib\net7.0 || goto :error
+copy unity\unity-embed-host\bin\%configuration%\net7.0\unity-embed-host.dll artifacts\bin\microsoft.netcore.app.runtime.win-%architecture%\%configuration%\runtimes\win-%architecture%\lib\net7.0 || goto :error
+copy unity\unity-embed-host\bin\%configuration%\net7.0\unity-embed-host.pdb artifacts\bin\microsoft.netcore.app.runtime.win-%architecture%\%configuration%\runtimes\win-%architecture%\lib\net7.0 || goto :error
 
 rem Every thing succeeded - jump to the end of the file and return a 0 exit code
 echo.

--- a/unity/Directory.Build.props
+++ b/unity/Directory.Build.props
@@ -1,0 +1,3 @@
+<Project>
+    <!-- Only here so that the default Directory.Build.props will not be used. -->
+</Project>

--- a/unity/Directory.Build.targets
+++ b/unity/Directory.Build.targets
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <ImportDirectorySolutionProps>false</ImportDirectorySolutionProps>
+    <ImportDirectorySolutionTargets>false</ImportDirectorySolutionTargets>
+  </PropertyGroup>
+</Project>

--- a/unity/before.managed.sln.targets
+++ b/unity/before.managed.sln.targets
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <ImportDirectorySolutionProps>false</ImportDirectorySolutionProps>
+    <ImportDirectorySolutionTargets>false</ImportDirectorySolutionTargets>
+  </PropertyGroup>
+</Project>

--- a/unity/coreclr-test/coreclr-test.csproj
+++ b/unity/coreclr-test/coreclr-test.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/unity/embed_api_tests/main.cpp
+++ b/unity/embed_api_tests/main.cpp
@@ -344,7 +344,7 @@ TEST(mono_type_get_name_full_returns_assembly_qualified_name)
     MonoClass *klass = GetClassHelper(kTestDLLNameSpace, kTestClassName);
     GET_AND_CHECK(type, mono_class_get_type(klass));
     GET_AND_CHECK(name , mono_type_get_name_full(type, MonoTypeNameFormat::MONO_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED));
-    CHECK(strcmp("TestDll.TestClass, coreclr-test, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35", name) == 0);
+    CHECK(strcmp("TestDll.TestClass, coreclr-test, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null", name) == 0);
     mono_unity_g_free(name);
 }
 
@@ -568,9 +568,9 @@ TEST(type_forwarder_lookup_results_in_identical_class)
 {
     MonoClass *directLookup = GetClassHelper(kTestDLLNameSpace, kTestClassName);
 #if defined(_DEBUG)
-    std::string testDllPath = abs_path_from_file("../../artifacts/bin/forwarder-test/Debug/net6.0/forwarder-test.dll");
+    std::string testDllPath = abs_path_from_file("../forwarder-test/bin/Debug/net7.0/forwarder-test.dll");
 #else
-    std::string testDllPath = abs_path_from_file("../../artifacts/bin/forwarder-test/Release/net6.0/forwarder-test.dll");
+    std::string testDllPath = abs_path_from_file("../forwarder-test/bin/Release/net7.0/forwarder-test.dll");
 #endif
     MonoAssembly *forwarderAssembly = mono_domain_assembly_open (g_domain, testDllPath.c_str());
     GET_AND_CHECK(forwarderImage, mono_assembly_get_image(forwarderAssembly));
@@ -2412,9 +2412,9 @@ void SetupMono(Mode mode)
 {
     g_Mode = mode;
 #if defined(_DEBUG)
-    std::string testDllPath = abs_path_from_file("../../artifacts/bin/coreclr-test/Debug/net6.0/coreclr-test.dll");
+    std::string testDllPath = abs_path_from_file("../coreclr-test/bin/Debug/net7.0/coreclr-test.dll");
 #else
-    std::string testDllPath = abs_path_from_file("../../artifacts/bin/coreclr-test/Release/net6.0/coreclr-test.dll");
+    std::string testDllPath = abs_path_from_file("../coreclr-test/bin/Release/net7.0/coreclr-test.dll");
 #endif
 
     std::string monoLibFolder;
@@ -2494,9 +2494,9 @@ void SetupMono(Mode mode)
     if (mode == CoreCLR)
     {
 #if defined(_DEBUG)
-        assembliesPaths = abs_path_from_file("../../artifacts/bin/unity-embed-host/Debug/net6.0");
+        assembliesPaths = abs_path_from_file("../unity-embed-hos/bin/Debug/net7.0");
 #else
-        assembliesPaths = abs_path_from_file("../../artifacts/bin/unity-embed-host/Release/net6.0");
+        assembliesPaths = abs_path_from_file("../unity-embed-hos/bin/Release/net7.0");
 #endif
         auto assembliesPathsChar = assembliesPaths.c_str();
         assembliesPathsNullTerm = new char[strlen(assembliesPathsChar) + 2];

--- a/unity/forwarder-test/forwarder-test.csproj
+++ b/unity/forwarder-test/forwarder-test.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/unity/unity-embed-host/unity-embed-host.csproj
+++ b/unity/unity-embed-host/unity-embed-host.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 


### PR DESCRIPTION
The Directory.Build.props and unity/Directory.build.targets prevents the inclusion of the top level files in the repo. This avoids customizations that are specific to building BCL projects.