### PR TITLE
Avoid setting assembly path for tests.

### DIFF
--- a/src/coreclr/vm/mono/mono_coreclr.cpp
+++ b/src/coreclr/vm/mono/mono_coreclr.cpp
@@ -2200,15 +2200,16 @@ extern "C" EXPORT_API MonoDomain* EXPORT_CC mono_jit_init_version(const char *fi
 
         SString etcPath (*s_EtcDir);
 
-        SString assemblyPaths (*s_AssemblyPaths);
-
         SString tpa;
         list_tpa(appPath, tpa);
 
         SString appPaths;
         appPaths += appPath;
-        appPaths += PATH_SEPARATOR;
-        appPaths += assemblyPaths;
+        if (s_AssemblyPaths != NULL)
+        {
+            appPaths += PATH_SEPARATOR;
+            appPaths += *s_AssemblyPaths;
+        }
 
         SString appNiPaths;
         appNiPaths += appPath;

--- a/unity/embed_api_tests/main.cpp
+++ b/unity/embed_api_tests/main.cpp
@@ -2489,23 +2489,6 @@ void SetupMono(Mode mode)
     printf("Setting up directories for Mono...\n");
     mono_set_dirs(monoLibFolder.c_str(), "");
 
-    char* assembliesPathsNullTerm;
-
-    if (mode == CoreCLR)
-    {
-#if defined(_DEBUG)
-        assembliesPaths = abs_path_from_file("../unity-embed-hos/bin/Debug/net7.0");
-#else
-        assembliesPaths = abs_path_from_file("../unity-embed-hos/bin/Release/net7.0");
-#endif
-        auto assembliesPathsChar = assembliesPaths.c_str();
-        assembliesPathsNullTerm = new char[strlen(assembliesPathsChar) + 2];
-        strcpy(assembliesPathsNullTerm, assembliesPathsChar);
-        assembliesPathsNullTerm[strlen(assembliesPathsChar) + 1] = '\0';
-        mono_set_assemblies_path_null_separated(assembliesPathsNullTerm);
-        delete [] assembliesPathsNullTerm;
-    }
-
     g_domain = mono_jit_init_version("myapp", "v4.0.30319");
     g_assembly = mono_domain_assembly_open(g_domain, testDllPath.c_str());
 }


### PR DESCRIPTION
The unity-embed-host assembly is already copied into the runtime directory as part of the build process. The path in this test code was wrong (it was `unity-embed-hos` rather than `unity-embed-host`) and the tests were still passing. We may want to improve the build/copy/test workflow, but this at least removes one part serving no purpose.