### PR TITLE
Fix mono_string_new_wrapper

### DIFF
--- a/src/coreclr/vm/mono/mono_coreclr.cpp
+++ b/src/coreclr/vm/mono/mono_coreclr.cpp
@@ -59,7 +59,6 @@ struct HostStruct
     ManagedStringPtr_t (*string_from_utf16)(const gunichar2* text);
     ManagedStringPtr_t (*string_new_len)(MonoDomain *domain, const char *text, guint32 length);
     ManagedStringPtr_t (*string_new_utf16)(MonoDomain * domain, const guint16 * text, gint32 length);
-    ManagedStringPtr_t (*string_new_wrapper)(const char* text);
 };
 HostStruct* g_HostStruct;
 
@@ -2972,8 +2971,7 @@ extern "C" EXPORT_API MonoString* EXPORT_CC mono_string_new_utf16(MonoDomain * d
 
 extern "C" EXPORT_API MonoString* EXPORT_CC mono_string_new_wrapper(const char* text)
 {
-    GCX_PREEMP(); // temporary until we sort out our GC thread model
-    return (MonoString*)g_HostStruct->string_new_wrapper(text);
+    return mono_string_new_len(mono_domain_get(), text, (guint32)strlen(text));
 }
 
 extern "C" EXPORT_API gunichar2* EXPORT_CC mono_string_to_utf16(MonoString *string_obj)

--- a/unity/embed_api_tests/main.cpp
+++ b/unity/embed_api_tests/main.cpp
@@ -1817,6 +1817,15 @@ TEST(mono_string_new_len_with_unicode_ascii_creates_string)
     }
 }
 
+TEST(mono_string_new_wrapper_with_unicode_ascii_creates_string)
+{
+    if (g_Mode == CoreCLR)
+    {
+        MonoString* str = mono_string_new_wrapper(kHelloWorldStringWithUnicode);
+        CHECK(str->length == 10);
+    }
+}
+
 void *ThreadFunc(void *arguments)
 {
     CHECK(mono_domain_get() == NULL);

--- a/unity/unity-embed-host/CoreCLRHost.cs
+++ b/unity/unity-embed-host/CoreCLRHost.cs
@@ -29,7 +29,6 @@ static unsafe class CoreCLRHost
         functionStruct->string_from_utf16 = &string_from_utf16;
         functionStruct->string_new_len = &string_new_len;
         functionStruct->string_new_utf16 = &string_new_utf16;
-        functionStruct->string_new_wrapper = &string_new_wrapper;
 
         return 0;
     }
@@ -69,14 +68,6 @@ static unsafe class CoreCLRHost
     static StringPtr string_new_utf16(void* domain /* unused */, ushort* text, uint length)
     {
         var s = new string((char*)text, 0, (int)length);
-        return StringToPtr(s);
-
-    }
-
-    [UnmanagedCallersOnly]
-    static StringPtr string_new_wrapper(sbyte* text)
-    {
-        var s = new string(text);
         return StringToPtr(s);
 
     }

--- a/unity/unity-embed-host/HostStruct.cs
+++ b/unity/unity-embed-host/HostStruct.cs
@@ -12,5 +12,4 @@ unsafe struct HostStruct
     public delegate* unmanaged<ushort*, StringPtr> string_from_utf16;
     public delegate* unmanaged<void* /*domain*/, sbyte* /*text*/, uint /*length*/, StringPtr> string_new_len;
     public delegate* unmanaged<void* /*domain*/, ushort* /*text*/, uint /*length*/, StringPtr> string_new_utf16;
-    public delegate* unmanaged<sbyte* /*text*/, StringPtr> string_new_wrapper;
 }


### PR DESCRIPTION
Route mono_string_new_wrapper to mono_string_new_len to ensure proper handling of non-ascii characters.