### PR TITLE
Removing string conversion functions that aren't GC safe.

### DIFF
--- a/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
+++ b/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
@@ -241,7 +241,6 @@ EXPORTS
         mono_string_new_len
         mono_string_new_utf16
         mono_string_new_wrapper
-        mono_string_to_utf16
         mono_string_to_utf8
         mono_stringify_assembly_name
         mono_thread_attach

--- a/src/coreclr/vm/mono/mono_coreclr.cpp
+++ b/src/coreclr/vm/mono/mono_coreclr.cpp
@@ -232,7 +232,9 @@ MonoString* InvokeFindPluginCallback(MonoString* path)
 {
     if (unity_find_plugin_callback)
     {
-        const char* result = unity_find_plugin_callback(mono_string_to_utf8(path));
+        SString sstr;
+        ((StringObject*)path)->GetSString(sstr);
+        const char* result = unity_find_plugin_callback(sstr.GetUTF8());
         if (result != NULL)
         {
             MonoString* result_mono = mono_string_new_wrapper(result);
@@ -2974,12 +2976,8 @@ extern "C" EXPORT_API MonoString* EXPORT_CC mono_string_new_wrapper(const char* 
     return mono_string_new_len(mono_domain_get(), text, (guint32)strlen(text));
 }
 
-extern "C" EXPORT_API gunichar2* EXPORT_CC mono_string_to_utf16(MonoString *string_obj)
-{
-    ASSERT_NOT_IMPLEMENTED;
-    return NULL;
-}
-
+// This API is not GC safe and is not used by the Unity runtime.
+// Once the embedding layer tests have been transitioned away from using this API it can be removed.
 extern "C" EXPORT_API char* EXPORT_CC mono_string_to_utf8(MonoString *string_obj)
 {
     SString sstr;

--- a/unity/unity-sources/Runtime/Mono/MonoFunctions.h
+++ b/unity/unity-sources/Runtime/Mono/MonoFunctions.h
@@ -80,10 +80,6 @@ DO_API(gboolean, mono_type_generic_inst_is_valuetype, (MonoType*))
 #endif
 DO_API(char*, mono_type_get_name_full, (MonoType * type, MonoTypeNameFormat format))
 
-#if PLATFORM_WIN
-DO_API(gunichar2*, mono_string_to_utf16, (MonoString * string_obj))
-#endif
-
 DO_API(const char*, mono_field_get_name, (MonoClassField * field))
 DO_API(MonoClass*, mono_field_get_parent, (MonoClassField * field))
 DO_API(MonoType*, mono_field_get_type, (MonoClassField * field))


### PR DESCRIPTION
Removed function;
* mono_string_to_utf16