### PR TITLE
Clean up from testing PR

### DIFF
--- a/unity/UnityEmbedHost.Tests/EmbeddingApiTests.cs
+++ b/unity/UnityEmbedHost.Tests/EmbeddingApiTests.cs
@@ -36,7 +36,7 @@ public class EmbeddingApiTests
     // }
 
     [Test]
-    public void Second()
+    public void GCHandleNewAndGetTarget()
     {
         var obj = new object();
         var handle1 = CoreCLRHost.gchandle_new_v2(Unsafe.As<object, IntPtr>(ref obj), false);

--- a/unity/unity-embed-host/AssemblyInfo.cs
+++ b/unity/unity-embed-host/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("UnityEmbedHost.Tests")]

--- a/unity/unity-embed-host/CoreCLRHost.cs
+++ b/unity/unity-embed-host/CoreCLRHost.cs
@@ -9,7 +9,7 @@ using System.Text;
 namespace Unity.CoreCLRHelpers;
 
 using StringPtr = IntPtr;
-public static unsafe partial class CoreCLRHost
+static unsafe partial class CoreCLRHost
 {
     static ALCWrapper alcWrapper;
     static FieldInfo assemblyHandleField;


### PR DESCRIPTION
* Make CoreCLRHost internal again. As part of the test changes I made CoreCLRHost public.  After thinking about it more, it's probably desirable to keep this internal.

* Rename a test method to something meaningful