### PR TITLE
Idea to make writing tests easier

### DIFF
--- a/unity/UnityEmbedHost.Tests/CoreCLRHostTestingWrappers.cs
+++ b/unity/UnityEmbedHost.Tests/CoreCLRHostTestingWrappers.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Unity.CoreCLRHelpers;
+
+namespace UnityEmbedHost.Tests;
+
+/// <summary>
+/// Wrappers around CoreCLRHost methods that make it easier to focus on writing tests
+/// </summary>
+static class CoreCLRHostTestingWrappers
+{
+    public static nint gchandle_new_v2(object obj, bool pinned)
+        => CoreCLRHost.gchandle_new_v2(Unsafe.As<object, IntPtr>(ref obj), pinned);
+
+    public static object? gchandle_get_target_v2(nint handleIn)
+    {
+        var result = CoreCLRHost.gchandle_get_target_v2(handleIn);
+        return Unsafe.As<IntPtr, object>(ref result);
+    }
+}

--- a/unity/UnityEmbedHost.Tests/EmbeddingApiTests.cs
+++ b/unity/UnityEmbedHost.Tests/EmbeddingApiTests.cs
@@ -39,17 +39,15 @@ public class EmbeddingApiTests
     public void GCHandleNewAndGetTarget()
     {
         var obj = new object();
-        var handle1 = CoreCLRHost.gchandle_new_v2(Unsafe.As<object, IntPtr>(ref obj), false);
+        var handle1 = CoreCLRHostTestingWrappers.gchandle_new_v2(obj, false);
         Assert.That(handle1, Is.Not.EqualTo(0));
-        var roundTrip = CoreCLRHost.gchandle_get_target_v2(handle1);
-        var result = Unsafe.As<IntPtr, object>(ref roundTrip);
+        var result = CoreCLRHostTestingWrappers.gchandle_get_target_v2(handle1);
         Assert.That(obj, Is.EqualTo(result));
 
         var obj2 = new object();
-        var handle2 = CoreCLRHost.gchandle_new_v2(Unsafe.As<object, IntPtr>(ref obj2), true);
+        var handle2 = CoreCLRHostTestingWrappers.gchandle_new_v2(obj2, true);
         Assert.That(handle2, Is.Not.EqualTo(0));
-        var roundTrip2 = CoreCLRHost.gchandle_get_target_v2(handle2);
-        var result2 = Unsafe.As<IntPtr, object>(ref roundTrip2);
+        var result2 = CoreCLRHostTestingWrappers.gchandle_get_target_v2(handle2);
         Assert.That(obj2, Is.EqualTo(result2));
 
         Assert.That(handle1, Is.Not.EqualTo(handle2));


### PR DESCRIPTION
While writing tests I've found it distracting to have to think about the `Unsafe.As` calls.  It adds mental overhead that I wonder if we can eliminate.  This PR is an attempt at an idea that might help. 

I added methods for the apis that have tests so far.  I'm currently working on `object_isinst` and this pattern is useful there as well.  It's not clear to me if this pattern will continue to be helpful.  But I think it's simple enough that it's worth giving a shot.

I thought about source generating this pattern.  I didn't for a combination of a few reasons.
1) It's not clear to me (yet) how to infer from the callback methods which parameters & return types should have `Unsafe.As` called on them.
2) Without a way to infer, attributes will be needed. 
3) It's still unclear how many of the methods on `CoreCLRHost` will be worth writing managed tests for.
4) It's unclear how many of the methods on `CoreCLRHost` will benefit from a wrapper method on `CoreCLRHostTestingWrappers`.

If this proves continually useful and we can figure out (1) or (2), then maybe we could add a source generator.