### PR TITLE
Improve unity-embed-host copying logic.

### DIFF
--- a/unity/unity-embed-host/unity-embed-host.csproj
+++ b/unity/unity-embed-host/unity-embed-host.csproj
@@ -11,5 +11,70 @@
   <ItemGroup>
     <ProjectReference Include="..\UnityEmbedHost.Generator\UnityEmbedHost.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <PropertyGroup>
+      <!-- CopyToCurrentConfigurationOnly=1 can be used to disable copying to both configurations -->
+      <CopyToDebugDestination Condition="'$(CopyToCurrentConfigurationOnly)'=='' Or '$(Configuration)'=='Debug'">true</CopyToDebugDestination>
+      <CopyToReleaseDestination Condition="'$(CopyToCurrentConfigurationOnly)'=='' Or '$(Configuration)'=='Release'">true</CopyToReleaseDestination>
+
+      <DestinationPlatformDirectoryName Condition="$([MSBuild]::IsOSPlatform('Windows'))">win</DestinationPlatformDirectoryName>
+      <DestinationPlatformDirectoryName Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux</DestinationPlatformDirectoryName>
+      <DestinationPlatformDirectoryName Condition="$([MSBuild]::IsOSPlatform('OSX'))">osx</DestinationPlatformDirectoryName>
+
+      <PostBuildDestinationX64Root>..\..\artifacts\bin\microsoft.netcore.app.runtime.$(DestinationPlatformDirectoryName)-x64</PostBuildDestinationX64Root>
+      <PostBuildDestinationX86Root>..\..\artifacts\bin\microsoft.netcore.app.runtime.$(DestinationPlatformDirectoryName)-x86</PostBuildDestinationX86Root>
+      <PostBuildDestinationARM64Root>..\..\artifacts\bin\microsoft.netcore.app.runtime.$(DestinationPlatformDirectoryName)-arm64</PostBuildDestinationARM64Root>
+
+      <!-- Debug -->
+      <PostBuildDestinationX64Debug>$(PostBuildDestinationX64Root)\Debug\runtimes\$(DestinationPlatformDirectoryName)-x64\lib\$(TargetFramework)</PostBuildDestinationX64Debug>
+      <PostBuildDestinationX86Debug>$(PostBuildDestinationX86Root)\Debug\runtimes\$(DestinationPlatformDirectoryName)-x86\lib\$(TargetFramework)</PostBuildDestinationX86Debug>
+      <PostBuildDestinationARM64Debug>$(PostBuildDestinationARM64Debug)\Debug\runtimes\$(DestinationPlatformDirectoryName)-arm64\lib\$(TargetFramework)</PostBuildDestinationARM64Debug>
+
+      <!-- Release -->
+      <PostBuildDestinationX64Release>$(PostBuildDestinationX64Root)\Release\runtimes\$(DestinationPlatformDirectoryName)-x64\lib\$(TargetFramework)</PostBuildDestinationX64Release>
+      <PostBuildDestinationX86Release>$(PostBuildDestinationX86Root)\Release\runtimes\$(DestinationPlatformDirectoryName)-x86\lib\$(TargetFramework)</PostBuildDestinationX86Release>
+      <PostBuildDestinationARM64Release>$(PostBuildDestinationARM64Debug)\Release\runtimes\$(DestinationPlatformDirectoryName)-arm64\lib\$(TargetFramework)</PostBuildDestinationARM64Release>
+    </PropertyGroup>
+    <ItemGroup>
+      <OuputFilesToCopy Include="$(OutputPath)\$(AssemblyName).*"/>
+    </ItemGroup>
+    <!-- Copy the current configuration to both the Release and Debug destinations.
+          This way you can debug the native code using whichever managed configuration you prefer
+    -->
+
+    <!-- Debug Copies -->
+    <Copy
+      Condition="Exists('$(PostBuildDestinationX64Debug)') And '$(CopyToDebugDestination)'=='true'"
+      SourceFiles="@(OuputFilesToCopy)"
+      DestinationFolder="$(PostBuildDestinationX64Debug)"
+    />
+    <Copy
+      Condition="Exists('$(PostBuildDestinationX86Debug)') And '$(CopyToDebugDestination)'=='true'"
+      SourceFiles="@(OuputFilesToCopy)"
+      DestinationFolder="$(PostBuildDestinationX86Debug)"
+    />
+    <Copy
+      Condition="Exists('$(PostBuildDestinationARM64Debug)') And '$(CopyToDebugDestination)'=='true'"
+      SourceFiles="@(OuputFilesToCopy)"
+      DestinationFolder="$(PostBuildDestinationARM64Debug)"
+    />
+
+    <!-- Release Copies -->
+    <Copy
+      Condition="Exists('$(PostBuildDestinationX64Release)') And '$(CopyToReleaseDestination)'=='true'"
+      SourceFiles="@(OuputFilesToCopy)"
+      DestinationFolder="$(PostBuildDestinationX64Release)"
+    />
+    <Copy
+      Condition="Exists('$(PostBuildDestinationX86Release)') And '$(CopyToReleaseDestination)'=='true'"
+      SourceFiles="@(OuputFilesToCopy)"
+      DestinationFolder="$(PostBuildDestinationX86Release)"
+    />
+    <Copy
+      Condition="Exists('$(PostBuildDestinationARM64Release)') And $(CopyToReleaseDestination)=='true'"
+      SourceFiles="@(OuputFilesToCopy)"
+      DestinationFolder="$(PostBuildDestinationARM64Release)"
+    />
+  </Target>
 
 </Project>


### PR DESCRIPTION
Currently, the build scripts copy `unity-embed-host.dll` and `unity-embed-host.pdb` to the coreclr artifact directory where it needs to exist.

There are a few downsides to this approach.

1) The scripts will break if we rename `unity-embed-host` 2) If you don't copy the file before running the native embedding tests your latest changes are not picked up 3) You can run the build script to take care of (2), however, this is time consuming.

This PR adds a post build target to do the file copying.  The advantages of this are 1) It won't break if we rename `unity-embed-host`
2) You don't need to do (2) or (3) to run the native embedding tests with your latest changes.  All you need to do is build the solution.

Some comments

* I made the target copy the current managed configuration to both the Release and Debug coreclr destinations.  This way you can debug the release native code while iterating on the managed code in Debug without having to change the configuration of `managed.sln` to match the native side in order to debug.

* My MSBuild skillz are passable.  I'm sure there is some way to cut down on the boiler plate.  If anyone knows how, I'm happy to make changes, otherwise I think this is clean enough for the time being.

* A added a property that lets you disable copying to both the Debug & Release destination.  I was worried there might be a scenario where this behavior isn't desired.  Maybe when building from scripts.  To disable when building from the command line pass `-p:CopyToCurrentConfigurationOnly=1`

* I made it so that the copying does not happen if the destination does not exist.