### PR TITLE
Give unsafe extensions their own home.

### DIFF
--- a/unity/UnityEmbedHost.Tests/CoreCLRHostTestingWrappers.cs
+++ b/unity/UnityEmbedHost.Tests/CoreCLRHostTestingWrappers.cs
@@ -11,14 +11,14 @@ namespace UnityEmbedHost.Tests;
 static class CoreCLRHostTestingWrappers
 {
     public static nint gchandle_new_v2(object obj, bool pinned)
-        => CoreCLRHost.gchandle_new_v2(obj.UnsafeAsIntPtr(), pinned);
+        => CoreCLRHost.gchandle_new_v2(obj.ToNativeRepresentation(), pinned);
 
     public static object? gchandle_get_target_v2(nint handleIn)
-        => CoreCLRHost.gchandle_get_target_v2(handleIn).UnsafeAs<object>();
+        => CoreCLRHost.gchandle_get_target_v2(handleIn).ToManagedRepresentation();
 
     public static object? object_isinst(object obj, Type klass)
-        => CoreCLRHost.object_isinst(obj.UnsafeAsIntPtr(), klass.TypeHandleIntPtr()).UnsafeAs<object>();
+        => CoreCLRHost.object_isinst(obj.ToNativeRepresentation(), klass.TypeHandleIntPtr()).ToManagedRepresentation();
 
     public static Type object_get_class(object obj)
-        => CoreCLRHost.object_get_class(obj.UnsafeAsIntPtr()).TypeFromHandleIntPtr();
+        => CoreCLRHost.object_get_class(obj.ToNativeRepresentation()).TypeFromHandleIntPtr();
 }

--- a/unity/unity-embed-host/CoreCLRHost.cs
+++ b/unity/unity-embed-host/CoreCLRHost.cs
@@ -76,28 +76,28 @@ static unsafe partial class CoreCLRHost
     [return: NativeCallbackType("uintptr_t")]
     public static IntPtr gchandle_new_v2([NativeCallbackType("MonoObject*")] IntPtr obj, bool pinned)
     {
-        GCHandle handle = GCHandle.Alloc(obj.UnsafeAs<object>(), pinned ? GCHandleType.Pinned : GCHandleType.Normal);
+        GCHandle handle = GCHandle.Alloc(obj.ToManagedRepresentation(), pinned ? GCHandleType.Pinned : GCHandleType.Normal);
         return GCHandle.ToIntPtr(handle);
     }
 
     [return: NativeCallbackType("uintptr_t")]
     public static IntPtr gchandle_new_weakref_v2([NativeCallbackType("MonoObject*")] IntPtr obj, bool track_resurrection)
     {
-        GCHandle handle = GCHandle.Alloc(obj.UnsafeAs<object>(), track_resurrection ? GCHandleType.WeakTrackResurrection : GCHandleType.Weak);
+        GCHandle handle = GCHandle.Alloc(obj.ToManagedRepresentation(), track_resurrection ? GCHandleType.WeakTrackResurrection : GCHandleType.Weak);
         return GCHandle.ToIntPtr(handle);
     }
 
     [return: NativeWrapperType("MonoObject*")]
     public static IntPtr gchandle_get_target_v2([NativeWrapperType("uintptr_t")] IntPtr handleIn)
-        => handleIn.ToGCHandle().Target.UnsafeAsIntPtr();
+        => handleIn.ToGCHandle().Target.ToNativeRepresentation();
 
     [return: NativeCallbackType("MonoObject*")]
     public static IntPtr object_isinst([NativeCallbackType("MonoObject*")] IntPtr obj, [NativeCallbackType("MonoClass*")] IntPtr klass)
-        => obj.UnsafeAs<object>().GetType().IsAssignableTo(klass.TypeFromHandleIntPtr()) ? obj : nint.Zero;
+        => obj.ToManagedRepresentation().GetType().IsAssignableTo(klass.TypeFromHandleIntPtr()) ? obj : nint.Zero;
 
     [return: NativeCallbackType("MonoClass*")]
     public static IntPtr object_get_class([NativeCallbackType("MonoObject*")] IntPtr obj)
-        => obj.UnsafeAs<object>().TypeHandleIntPtr();
+        => obj.ToManagedRepresentation().TypeHandleIntPtr();
 
     static StringPtr StringToPtr(string s)
     {

--- a/unity/unity-embed-host/Extensions.cs
+++ b/unity/unity-embed-host/Extensions.cs
@@ -18,15 +18,6 @@ static class Extensions
     public static nint TypeHandleIntPtr(this Type type)
         => RuntimeTypeHandle.ToIntPtr(type.TypeHandle);
 
-    public static T UnsafeAs<T>(this nint intPtr)
-        => Unsafe.As<nint, T>(ref intPtr);
-
-    public static nint UnsafeAsIntPtr(this object obj)
-        => obj.UnsafeAs<nint>();
-
-    public static T UnsafeAs<T>(this object obj)
-        => Unsafe.As<object, T>(ref obj);
-
     public static GCHandle ToGCHandle(this nint intPtr)
         => GCHandle.FromIntPtr(intPtr);
 }

--- a/unity/unity-embed-host/UnsafeExtensions.cs
+++ b/unity/unity-embed-host/UnsafeExtensions.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+namespace Unity.CoreCLRHelpers;
+
+/// <summary>
+/// These extensions are specifically for transitioning to/from our current native representation
+/// These are not GC safe and will change in the future
+/// </summary>
+static class UnsafeExtensions
+{
+    public static object ToManagedRepresentation(this nint intPtr)
+        => Unsafe.As<nint, object>(ref intPtr);
+
+    public static nint ToNativeRepresentation(this object obj)
+        => Unsafe.As<object, nint>(ref obj);
+}


### PR DESCRIPTION
The managed tests still have gc problems.  This just organizes the problematic code a little more nicely.