### PR TITLE
Various clean up

### DIFF
--- a/unity/CITools/BuildDriver/EmbeddingHost.cs
+++ b/unity/CITools/BuildDriver/EmbeddingHost.cs
@@ -22,7 +22,7 @@ public class EmbeddingHost
 
         ProcessStartInfo psi = new();
         psi.FileName = Paths.RepoRoot.Combine(DotNet);
-        psi.Arguments = $"{type} unity/managed.sln -c {gConfig.Configuration}";
+        psi.Arguments = $"{type} unity/managed.sln -c {gConfig.Configuration} -v:{gConfig.DotNetVerbosity}";
         psi.WorkingDirectory = Paths.RepoRoot;
 
         Utils.RunProcess(psi, gConfig);

--- a/unity/CITools/BuildDriver/Extensions.cs
+++ b/unity/CITools/BuildDriver/Extensions.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+
+namespace BuildDriver;
+
+public static class Extensions
+{
+    public static string AggregateWithSpace(this IEnumerable<string> elements)
+    {
+        return elements.AggregateWithSpace(new StringBuilder());
+    }
+
+    public static string AggregateWithSpace(this IEnumerable<string> elements, StringBuilder builder)
+    {
+        return elements.AggregateWith(" ", builder);
+    }
+
+    public static string AggregateWith(this IEnumerable<string> elements, string separator, StringBuilder builder)
+    {
+        bool addSep = false;
+        foreach (var item in elements)
+        {
+            if (addSep)
+                builder.Append(separator);
+            builder.Append(item);
+            addSep = true;
+        }
+
+        return builder.ToString();
+    }
+}

--- a/unity/CITools/BuildDriver/GlobalConfig.cs
+++ b/unity/CITools/BuildDriver/GlobalConfig.cs
@@ -8,4 +8,5 @@ public class GlobalConfig
     public required string Architecture;
     public required string Configuration;
     public required bool Silent;
+    public required string DotNetVerbosity;
 }

--- a/unity/CITools/BuildDriver/NullGC.cs
+++ b/unity/CITools/BuildDriver/NullGC.cs
@@ -17,6 +17,8 @@ public class NullGC
         Console.WriteLine("Unity: Building Null GC");
         Console.WriteLine("***********************");
 
+        var hideOutput = gConfig.Silent || gConfig.DotNetVerbosity == "quiet";
+
         NPath workingDir = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
             Paths.UnityGC : Paths.UnityGC.CreateDirectory(gConfig.Configuration);
 
@@ -33,12 +35,12 @@ public class NullGC
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             sInfo.Arguments = $"{extraArchDefine}-DCMAKE_BUILD_TYPE={gConfig.Configuration} ..";
 
-        Utils.RunProcess(sInfo, gConfig);
+        Utils.RunProcess(sInfo, silent: hideOutput);
 
         sInfo.Arguments = "--build .";
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             sInfo.Arguments = $"--build . --config {gConfig.Configuration}";
 
-        Utils.RunProcess(sInfo, gConfig);
+        Utils.RunProcess(sInfo, silent: hideOutput);
     }
 }

--- a/unity/CITools/BuildDriver/Program.cs
+++ b/unity/CITools/BuildDriver/Program.cs
@@ -59,8 +59,18 @@ public class Program
         Console.WriteLine($"\tConfiguration:\t\t{configuration}");
         Console.WriteLine("*****************************");
 
-        GlobalConfig gConfig = new (){ Architecture = architecture, Configuration = configuration, Silent = silent};
+        GlobalConfig gConfig = new ()
+        {
+            Architecture = architecture,
+            Configuration = configuration,
+            Silent = silent,
+            DotNetVerbosity = "quiet"
+        };
+
+        // We need to build even when `skipBuild` is false because on CI we have the build and tests split into separate jobs.  And the way we have artifacts setup,
+        // we don't retain anything built under `unity`.  And therefore we need to rebuild it so that tests that depend on something in managed.sln can find what they need
         EmbeddingHost.Build(gConfig);
+
         if (!skipBuild)
         {
             NullGC.Build(gConfig);

--- a/unity/CITools/BuildDriver/Utils.cs
+++ b/unity/CITools/BuildDriver/Utils.cs
@@ -8,17 +8,19 @@ namespace BuildDriver;
 public class Utils
 {
     public static string WinArchitecture(string arch) => arch.Equals("x86") ? "Win32" : "x64";
-    public static void RunProcess(ProcessStartInfo psi) => RunProcess(psi,
-        new GlobalConfig() { Configuration = "Release", Architecture = "x64", Silent = false });
-    public static void RunProcess(ProcessStartInfo psi, GlobalConfig gConfig)
+
+    public static void RunProcess(ProcessStartInfo psi, GlobalConfig config)
+        => RunProcess(psi, config.Silent);
+
+    public static void RunProcess(ProcessStartInfo psi, bool silent = false)
     {
-        if (!gConfig.Silent)
+        if (!silent)
             Console.WriteLine($"Running: {psi.FileName} {psi.Arguments}");
         using (Process proc = new())
         {
             proc.StartInfo = psi;
             proc.StartInfo.UseShellExecute = false;
-            if (gConfig.Silent)
+            if (silent)
             {
                 proc.StartInfo.RedirectStandardOutput = true;
                 proc.StartInfo.RedirectStandardError = true;
@@ -29,7 +31,7 @@ public class Utils
             proc.WaitForExit();
             if (proc.ExitCode != 0)
             {
-                if (gConfig.Silent)
+                if (silent)
                 {
                     Console.WriteLine(proc.StandardOutput.ReadToEnd());
                     Console.WriteLine(proc.StandardError.ReadToEnd());


### PR DESCRIPTION
* EmbeddingHost.Build should be behind an `if (!skipBuild)`

* Add `DotNetVerbosity` to global config and pass to commands that respect it.

* Default verbosity to quiet to cut down on output spam.

* Add logic to NullGC to silence output when `DotNetVerbosity` is quiet.

* Refactor the `RunProcess` overload that creates a global config.  This is tedious to update each time a new property is added to GlobalConfig.  Having an overload that accepts a `GlobalConfig` while the main one has `silent` gives the same behavior.

* Avoid ninja message