### PR TITLE
New command line test abilities

### DIFF
--- a/unity/CITools/BuildDriver/TestTargets.cs
+++ b/unity/CITools/BuildDriver/TestTargets.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace BuildDriver;
+
+[Flags]
+public enum TestTargets
+{
+    None = 1 << 0,
+    Embedding = 1 << 1,
+    CoreClr = 1 << 2,
+    All = ~0
+}


### PR DESCRIPTION
* Support `--test=embedding` or `--test=coreclr`

* Add `--build` which can be used with `--test` to cause the test to build and test

Now you can do
```
.yamato\scripts\build_yamato.cmd --test=embedding --build
```

And it gives a tighter iteration loop for running the embedding api tests.