### PR TITLE
Support custom native wrapper name

### DIFF
--- a/unity/UnityEmbedHost.Generator/NativeGeneration.cs
+++ b/unity/UnityEmbedHost.Generator/NativeGeneration.cs
@@ -12,6 +12,7 @@ static class NativeGeneration
     const string NoNativeWrapperAttributeName = "NoNativeWrapperAttribute";
     public const string NativeWrapperTypeAttributeName = "NativeWrapperTypeAttribute";
     public const string NativeCallbackTypeAttributeName = "NativeCallbackTypeAttribute";
+    public const string NativeWrapperNameAttributeName = "NativeWrapperNameAttribute";
 
     static readonly DiagnosticDescriptor NativeDestinationNotFound = new (
         id: "EMBEDHOSTGEN001",

--- a/unity/UnityEmbedHost.Generator/NativeUtils.cs
+++ b/unity/UnityEmbedHost.Generator/NativeUtils.cs
@@ -9,7 +9,11 @@ namespace UnityEmbedHost.Generator;
 static class NativeUtils
 {
     public static string NativeWrapperName(this IMethodSymbol methodSymbol)
-        => $"mono_{methodSymbol.Name}";
+    {
+        if (methodSymbol.TryFirstAttributeValue<string>(NativeGeneration.NativeWrapperNameAttributeName, out var value))
+            return value!;
+        return $"mono_{methodSymbol.Name}";
+    }
 
     public static string NativeCallbackName(this IMethodSymbol methodSymbol)
         => methodSymbol.Name;

--- a/unity/UnityEmbedHost.Generator/Utils.cs
+++ b/unity/UnityEmbedHost.Generator/Utils.cs
@@ -18,6 +18,9 @@ static class Utils
     public static bool TryReturnTypeFirstAttributeValue<T>(this IMethodSymbol methodSymbol, string attributeName, out T? value)
         => methodSymbol.GetReturnTypeAttributes().TryFirstAttributeValue(attributeName, out value);
 
+    public static bool TryFirstAttributeValue<T>(this IMethodSymbol methodSymbol, string attributeName, out T? value)
+        => methodSymbol.GetAttributes().TryFirstAttributeValue<T>(attributeName, out value);
+
     public static bool TryFirstAttributeValue<T>(this ImmutableArray<AttributeData> attributes, string attributeName, out T? value)
     {
         var explicitNativeTypeAttribute = attributes.FirstOrDefault(attr => attr.AttributeClass!.Name == attributeName);

--- a/unity/unity-embed-host/NativeWrapperNameAttribute.cs
+++ b/unity/unity-embed-host/NativeWrapperNameAttribute.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Unity.CoreCLRHelpers;
+
+[AttributeUsage(AttributeTargets.Method)]
+public class NativeWrapperNameAttribute : Attribute
+{
+    public NativeWrapperNameAttribute(string name)
+    {
+    }
+}


### PR DESCRIPTION
Some apis don't follow the `mono_` prefix.  This attribute gives the ability to explicitly define the name