### PR TITLE
Switching to use System.CommandLine instead of custom argument parsing

### DIFF
--- a/unity/CITools/BuildDriver/BuildDriver.csproj
+++ b/unity/CITools/BuildDriver/BuildDriver.csproj
@@ -8,4 +8,8 @@
         <LangVersion>preview</LangVersion>
     </PropertyGroup>
 
+    <ItemGroup>
+      <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.23172.1" />
+    </ItemGroup>
+
 </Project>

--- a/unity/CITools/BuildDriver/BuildTargets.cs
+++ b/unity/CITools/BuildDriver/BuildTargets.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace BuildDriver;
+
+[Flags]
+public enum BuildTargets
+{
+    None = 0,
+    CoreCLR = 1 << 0,
+    NullGC = 1 << 1,
+    EmbeddingHost = 1 << 2,
+    All = CoreCLR | NullGC | EmbeddingHost
+}

--- a/unity/CITools/BuildDriver/CoreCLR.cs
+++ b/unity/CITools/BuildDriver/CoreCLR.cs
@@ -22,6 +22,7 @@ public class CoreCLR
             "-subset clr+libs",
             $"-a {gConfig.Architecture}",
             $"-c {gConfig.Configuration}",
+            $"-v:{Utils.DotNetVerbosity(gConfig.VerbosityLevel)}"
         };
 
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -107,6 +108,7 @@ public class CoreCLR
             "-test /p:RunSmokeTestsOnly=true",
             $"-a {gConfig.Architecture}",
             $"-c {gConfig.Configuration}",
+            $"-v:{Utils.DotNetVerbosity(gConfig.VerbosityLevel)}"
         };
 
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/unity/CITools/BuildDriver/EmbeddingHost.cs
+++ b/unity/CITools/BuildDriver/EmbeddingHost.cs
@@ -22,7 +22,7 @@ public class EmbeddingHost
 
         ProcessStartInfo psi = new();
         psi.FileName = Paths.RepoRoot.Combine(DotNet);
-        psi.Arguments = $"{type} unity/managed.sln -c {gConfig.Configuration} -v:{gConfig.DotNetVerbosity}";
+        psi.Arguments = $"{type} unity/managed.sln -c {gConfig.Configuration} -v:{Utils.DotNetVerbosity(gConfig.VerbosityLevel)}";
         psi.WorkingDirectory = Paths.RepoRoot;
 
         Utils.RunProcess(psi, gConfig);

--- a/unity/CITools/BuildDriver/GlobalConfig.cs
+++ b/unity/CITools/BuildDriver/GlobalConfig.cs
@@ -7,6 +7,5 @@ public class GlobalConfig
 {
     public required string Architecture;
     public required string Configuration;
-    public required bool Silent;
-    public required string DotNetVerbosity;
+    public required Verbosity VerbosityLevel;
 }

--- a/unity/CITools/BuildDriver/NullGC.cs
+++ b/unity/CITools/BuildDriver/NullGC.cs
@@ -17,8 +17,6 @@ public class NullGC
         Console.WriteLine("Unity: Building Null GC");
         Console.WriteLine("***********************");
 
-        var hideOutput = gConfig.Silent || gConfig.DotNetVerbosity == "quiet";
-
         NPath workingDir = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
             Paths.UnityGC : Paths.UnityGC.CreateDirectory(gConfig.Configuration);
 
@@ -35,12 +33,12 @@ public class NullGC
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             sInfo.Arguments = $"{extraArchDefine}-DCMAKE_BUILD_TYPE={gConfig.Configuration} ..";
 
-        Utils.RunProcess(sInfo, silent: hideOutput);
+        Utils.RunProcess(sInfo, gConfig);
 
         sInfo.Arguments = "--build .";
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             sInfo.Arguments = $"--build . --config {gConfig.Configuration}";
 
-        Utils.RunProcess(sInfo, silent: hideOutput);
+        Utils.RunProcess(sInfo, gConfig);
     }
 }

--- a/unity/CITools/BuildDriver/Program.cs
+++ b/unity/CITools/BuildDriver/Program.cs
@@ -28,7 +28,8 @@ public class Program
                         result.AddError($"'{token.Value}' is not a valid build target");
                 }
                 return retVal;
-            }
+            },
+            Description = "Select how much of CoreCLR you wish to build."
         };
         var testOption = new Option<TestTargets>("--test")
         {
@@ -47,7 +48,8 @@ public class Program
                         result.AddError($"'{token.Value}' is not a valid test target");
                 }
                 return retVal;
-            }
+            },
+            Description = "Select how much of CoreCLR you wish to test."
         };
         var architectureOption = new Option<string>("--architecture", "--a", "--arch")
         {
@@ -73,8 +75,16 @@ public class Program
                 result.AddError($"The value of {configurationOption.Name} must be either Release or Debug");
         });
 
-        var silentOption = new Option<bool>("--silent", "--s");
-        var zipOption = new Option<bool>("--zip", "--z") { DefaultValueFactory = (_) => RunningOnYamato()};
+        var verbosityOption = new Option<Verbosity>("--verbosity", "--v")
+        {
+            Description = "Set the verbosity level for the build.",
+            DefaultValueFactory = (_) => Verbosity.Normal
+        };
+        var zipOption = new Option<bool>("--zip", "--z")
+        {
+            DefaultValueFactory = (_) => RunningOnYamato(),
+            Description = "Produce zip artifacts. This is only used when building."
+        };
 
         RootCommand rootCommand = new RootCommand("Unity CoreCLR Builder")
         {
@@ -82,7 +92,7 @@ public class Program
             testOption,
             architectureOption,
             configurationOption,
-            silentOption,
+            verbosityOption,
             zipOption
         };
         rootCommand.SetAction(Run);
@@ -114,8 +124,7 @@ public class Program
             {
                 Architecture = architecture ?? GetArchitectures()[0],
                 Configuration = configuration ?? "Release",
-                Silent = context.ParseResult.GetValue(silentOption),
-                DotNetVerbosity = "quiet"
+                VerbosityLevel = context.ParseResult.GetValue(verbosityOption)
             };
 
             // We always need to build the embedding host because on CI we have the build and tests split into separate jobs.  And the way we have artifacts setup,

--- a/unity/CITools/BuildDriver/SevenZip.cs
+++ b/unity/CITools/BuildDriver/SevenZip.cs
@@ -31,7 +31,7 @@ public class SevenZip
     {
         NPath zipArtifact = new (Environment.GetEnvironmentVariable("ARTIFACT_FILENAME") ??
                                  $"dotnet-unity-{gConfig.Architecture}.7z");
-        SevenZip.Create7z(zipExe, artifacts, Paths.Artifacts.Combine("unity", zipArtifact));
+        Create7z(zipExe, artifacts, Paths.Artifacts.Combine("unity", zipArtifact));
     }
 
     public static void Get7ZipUrl(out string url, out string filename)

--- a/unity/CITools/BuildDriver/TestTargets.cs
+++ b/unity/CITools/BuildDriver/TestTargets.cs
@@ -6,8 +6,8 @@ namespace BuildDriver;
 [Flags]
 public enum TestTargets
 {
-    None = 1 << 0,
-    Embedding = 1 << 1,
-    CoreClr = 1 << 2,
-    All = ~0
+    None = 0,
+    Embedding = 1 << 0,
+    CoreClr = 1 << 1,
+    All = Embedding | CoreClr
 }

--- a/unity/CITools/BuildDriver/Utils.cs
+++ b/unity/CITools/BuildDriver/Utils.cs
@@ -9,8 +9,11 @@ public class Utils
 {
     public static string WinArchitecture(string arch) => arch.Equals("x86") ? "Win32" : "x64";
 
+    public static string DotNetVerbosity(Verbosity val) =>
+        val == Verbosity.Silent ? Verbosity.Quiet.ToString().ToLower() : val.ToString().ToLower();
+
     public static void RunProcess(ProcessStartInfo psi, GlobalConfig config)
-        => RunProcess(psi, config.Silent);
+        => RunProcess(psi, config.VerbosityLevel == Verbosity.Silent);
 
     public static void RunProcess(ProcessStartInfo psi, bool silent = false)
     {

--- a/unity/CITools/BuildDriver/Verbosity.cs
+++ b/unity/CITools/BuildDriver/Verbosity.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace BuildDriver;
+
+public enum Verbosity
+{
+    Silent,
+    Quiet,
+    Minimal,
+    Normal,
+    Detailed,
+    Diagnostic
+}


### PR DESCRIPTION
Help Output:
```
Description:
  Unity CoreCLR Builder

Usage:
  BuildDriver [options]

Options:
  --b, --build <All|CoreCLR|EmbeddingHost|None|NullGC>  Select how much of CoreCLR you wish to build.
  --test <All|CoreClr|Embedding|None>                   Select how much of CoreCLR you wish to test.
  --a, --arch, --architecture                           Set the target architecture [default: x64]
  --c, --config, --configuration                        Set the build type [default: Release]
  --v, --verbosity                                      Set the verbosity level for the build. [default: Normal]
  <Detailed|Diagnostic|Minimal|Normal|Quiet|Silent>
  --z, --zip                                            Produce zip artifacts. This is only used when building.
                                                        [default: False]
  -?, -h, --help                                        Show help and usage information
```