### PR TITLE
Git ignore clean up.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -366,8 +366,3 @@ src/coreclr/System.Private.CoreLib/common
 # Temporary artifacts from local libraries stress builds
 .dotnet-daily/
 run-stress-*
-
-# Unity emebdding API tests
-unity/embed_api_tests/ALL_BUILD.*
-unity/embed_api_tests/ZERO_CHECK.*
-unity/embed_api_tests/mono_test_app.*

--- a/unity/.gitignore
+++ b/unity/.gitignore
@@ -1,0 +1,5 @@
+# Unity emebdding API tests
+embed_api_tests/ALL_BUILD.*
+embed_api_tests/ZERO_CHECK.*
+embed_api_tests/mono_test_app*
+embed_api_tests/Makefile


### PR DESCRIPTION
* Move the changes from https://github.com/Unity-Technologies/runtime/commit/840f3a70f19118d75c3f8ea3207cadf5dacecb30 into `unity/.gitignore`.  It would be better to maintain our own separate ignore file in order to reduce the risk of conflicts.

* Fix  `mono_test_app.*` not covering the executable name on non windows platforms since it's simply `mono_test_app`

* Add `embed_api_tests/Makefile` since that is another file that is generated and should be ignored.