### PR TITLE
GC safety during managed tests

### DIFF
--- a/unity/UnityEmbedHost.Tests/EmbeddingApiTests.cs
+++ b/unity/UnityEmbedHost.Tests/EmbeddingApiTests.cs
@@ -183,7 +183,6 @@ public class EmbeddingApiTests
     [TestCase(typeof(ValueAnimal), 5)]
     [TestCase(typeof(int[]), 2)]
     [TestCase(typeof(int), 1000000)]
-    [Ignore("Unstable due to CoreCLR GC")]
     public void ArrayNew(Type arrayType, int length)
     {
         Assert.That(CoreCLRHostWrappers.array_new(arrayType, length), Is.EquivalentTo(Array.CreateInstance(arrayType, length)));
@@ -195,7 +194,6 @@ public class EmbeddingApiTests
     [TestCase(typeof(ValueAnimal), 5, 5)]
     [TestCase(typeof(int[]), 2, 1)]
     [TestCase(typeof(int), 1000, 1000)]
-    [Ignore("Unstable due to CoreCLR GC")]
     public void ArrayNew2d(Type arrayType, int size0, int size1)
     {
         var result = CoreCLRHostWrappers.unity_array_new_2d(arrayType, size0, size1);

--- a/unity/unity-embed-host/UnsafeExtensions.cs
+++ b/unity/unity-embed-host/UnsafeExtensions.cs
@@ -1,7 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace Unity.CoreCLRHelpers;
 
@@ -11,9 +16,43 @@ namespace Unity.CoreCLRHelpers;
 /// </summary>
 static class UnsafeExtensions
 {
+#if TESTING_UNITY_CORECLR
+    private static readonly ConcurrentBag<GCHandle> handles = new ();
+#endif
+
     public static object ToManagedRepresentation(this nint intPtr)
         => Unsafe.As<nint, object>(ref intPtr);
 
     public static nint ToNativeRepresentation(this object obj)
-        => Unsafe.As<object, nint>(ref obj);
+    {
+#if TESTING_UNITY_CORECLR
+        WorkaroundToGetGCSafety(obj);
+#endif
+        return Unsafe.As<object, nint>(ref obj);
+    }
+
+#if TESTING_UNITY_CORECLR
+    static void WorkaroundToGetGCSafety(object obj)
+    {
+        var valueToPin = 1;
+        var handle = GCHandle.Alloc(valueToPin, GCHandleType.Pinned);
+
+        // Now do the same thing as
+        // https://github.com/Unity-Technologies/runtime/blob/unity-main/src/libraries/System[…].Private.CoreLib/src/System/Runtime/InteropServices/GCHandle.cs
+        // Except by pass the pinnable checks so that we can use the GCHandle to hang onto our object
+        var getHandleValueMethod =
+            typeof(GCHandle).GetMethod("GetHandleValue", BindingFlags.Static | BindingFlags.NonPublic);
+        var internalSetMethod =
+            typeof(GCHandle).GetMethod("InternalSet", BindingFlags.Static | BindingFlags.NonPublic);
+
+        var handleValue = getHandleValueMethod.Invoke(handle, new[] {(object)GCHandle.ToIntPtr(handle)});
+        internalSetMethod.Invoke(handle, new []
+        {
+            handleValue,
+            obj
+        });
+
+        handles.Add(handle);
+    }
+#endif
 }

--- a/unity/unity-embed-host/unity-embed-host.csproj
+++ b/unity/unity-embed-host/unity-embed-host.csproj
@@ -8,6 +8,9 @@
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>$(IntermediateOutputPath)</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TestingUnityCoreClr)' == '1' Or '$(TestingUnityCoreClr)' == 'true'">
+    <DefineConstants>$(DefineConstants);TESTING_UNITY_CORECLR</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\UnityEmbedHost.Generator\UnityEmbedHost.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>


### PR DESCRIPTION
This is a hacky approach to get GC safety during the managed tests without using the Null GC (which I wasn't able to get working on macOS and Linux)

I removed the Ignore's that @UnityAlex used to stabilize the tests.