### PR TITLE
Need to initialize state

### DIFF
--- a/unity/UnityEmbedHost.Tests/CoreCLRHostSetup.cs
+++ b/unity/UnityEmbedHost.Tests/CoreCLRHostSetup.cs
@@ -6,16 +6,17 @@ using Unity.CoreCLRHelpers;
 
 namespace UnityEmbedHost.Tests;
 
-#if TESTING_UNITY_CORECLR
 [SetUpFixture]
-#endif
-public class NativeSetup
+public class CoreCLRHostSetup
 {
-#if TESTING_UNITY_CORECLR
+
     [OneTimeSetUp]
-#endif
     public void Initialize()
     {
+#if TESTING_UNITY_CORECLR
         CoreCLRHostNative.InitializeNative();
+#else
+        CoreCLRHost.InitState();
+#endif
     }
 }

--- a/unity/unity-embed-host/CoreCLRHost.cs
+++ b/unity/unity-embed-host/CoreCLRHost.cs
@@ -20,14 +20,19 @@ static unsafe partial class CoreCLRHost
         if (Marshal.SizeOf<HostStruct>() != structSize)
             throw new Exception("Invalid struct size");
 
-        alcWrapper = new ALCWrapper();
-        assemblyHandleField = typeof(Assembly).Assembly.GetType("System.Reflection.RuntimeAssembly").GetField("m_assembly", BindingFlags.Instance | BindingFlags.NonPublic);
-        if (assemblyHandleField == null)
-            throw new Exception("Failed to find RuntimeAssembly.m_assembly field.");
+        InitState();
 
         InitHostStruct(functionStruct);
 
         return 0;
+    }
+
+    internal static void InitState()
+    {
+        alcWrapper = new ALCWrapper();
+        assemblyHandleField = typeof(Assembly).Assembly.GetType("System.Reflection.RuntimeAssembly").GetField("m_assembly", BindingFlags.Instance | BindingFlags.NonPublic);
+        if (assemblyHandleField == null)
+            throw new Exception("Failed to find RuntimeAssembly.m_assembly field.");
     }
 
     static partial void InitHostStruct(HostStruct* functionStruct);


### PR DESCRIPTION
When running the tests that directly call the callback methods we still need to initialize some state.

This wasn't an issue previously because we didn't call any of the methods that depend on this state.  I think this will change soon.  Even if it doesn't, it's still technically more correct and should prevent confusion down the road.