### PR TITLE
Update README.md

### DIFF
--- a/unity/README.md
+++ b/unity/README.md
@@ -18,6 +18,7 @@ The CoreCLR runtime and class libraries can be built and tested locally for Wind
 ### Building the CoreCLR runtime and class libraries
 
 To build locally, use the platform-specific shell script in .yamato/scripts. Either `build_yamato.cmd` or `build_yamato.sh`:
+_Note that this will require having ninja installed, which is an optional requirement._
 
 To view all possible arguments run:
 ```


### PR DESCRIPTION
Added a note to avoid confusion, when building on mac and following the requirements setup, ninja is not installed, and trying to run build_yamato will fail due to that.