### PR TITLE
Fix DoNotGenerate

### DIFF
--- a/unity/UnityEmbedHost.Generator/NativeGeneration.cs
+++ b/unity/UnityEmbedHost.Generator/NativeGeneration.cs
@@ -166,6 +166,9 @@ static class NativeGeneration
                 continue;
             }
 
+            if (unwritten.m.NativeFunctionOptions() == NativeFunctionOptions.DoNotGenerate)
+                continue;
+
             AppendNativeWrapperMethod(sb, unwritten.m,
                 // Better safe than sorry?  Control may need to be exposed
                 includeGcxPreEmp: true);


### PR DESCRIPTION
```[NativeFunction(NativeFunctionOptions.DoNotGenerate)]```

was not working correctly and resulted in native functions being written for `load_assembly_from_data` and `load_assembly_from_path`