### PR TITLE
Exception handling

### DIFF
--- a/unity/UnityEmbedHost.Generator/CoreCLRHostGenerator.cs
+++ b/unity/UnityEmbedHost.Generator/CoreCLRHostGenerator.cs
@@ -73,7 +73,19 @@ static unsafe partial class CoreCLRHost
         {
             sb.AppendLine("    [System.Runtime.InteropServices.UnmanagedCallersOnly]");
             string signature = methodSymbol.FormatMethodParametersForMethodSignature();
-            sb.AppendLine($"    static {methodSymbol.ReturnType} {methodSymbol.Name}_native({signature}) => {methodSymbol.Name}({FormatMethodParametersNames(methodSymbol)});");
+            sb.AppendLine($"    static {methodSymbol.ReturnType} {methodSymbol.Name}_native({signature})");
+            sb.AppendLine("    {");
+            sb.AppendLine("        try");
+            sb.AppendLine("        {");
+            sb.AppendLine($"            return {methodSymbol.Name}({FormatMethodParametersNames(methodSymbol)});");
+            sb.AppendLine("        }");
+            sb.AppendLine("        catch (System.Exception e)");
+            sb.AppendLine("        {");
+            sb.AppendLine("            Log(e.ToString());");
+            sb.AppendLine("            System.Environment.Exit(1);");
+            sb.AppendLine("        }");
+            sb.AppendLine("        return default;");
+            sb.AppendLine("    }");
             sb.AppendLine();
         }
 

--- a/unity/UnityEmbedHost.Tests/NativeEmbeddingApiTests.cs
+++ b/unity/UnityEmbedHost.Tests/NativeEmbeddingApiTests.cs
@@ -14,4 +14,14 @@ namespace UnityEmbedHost.Tests;
 public class NativeEmbeddingApiTests : BaseEmbeddingApiTests
 {
     internal override ICoreCLRHostWrapper ClrHost { get; } = new CoreCLRHostNativeWrappers();
+
+    [Test]
+    [Category("ExcludeFromNormalTestRun")]
+    public void ExceptionDoesNotCauseACrash()
+    {
+        var fieldInfo = typeof(Cat).GetField(nameof(Cat.EarCount));
+        // Pass the wrong type to cause an exception
+        var result = ClrHost.field_get_object(typeof(Mammal), fieldInfo!.FieldHandle);
+        Assert.IsNull(result);
+    }
 }

--- a/unity/unity-embed-host/CoreCLRHostNative.cs
+++ b/unity/unity-embed-host/CoreCLRHostNative.cs
@@ -19,10 +19,10 @@ static partial class CoreCLRHostNative
     }
 
     [UnmanagedCallersOnly]
-    static unsafe int InitCallback(IntPtr ptr, int size)
-        => CoreCLRHost.InitMethod((HostStruct*)ptr, size);
+    static unsafe int InitCallback(IntPtr ptr, int size, IntPtr hostStructNativePtr, int hostStructNativeSize)
+        => CoreCLRHost.InitMethod((HostStruct*)ptr, size, (HostStructNative*)hostStructNativePtr, hostStructNativeSize);
 
     [DllImport("coreclr", EntryPoint = nameof(mono_unity_initialize_host_apis), CharSet = CharSet.Unicode, ExactSpelling = true,
         CallingConvention = CallingConvention.Cdecl)]
-    public unsafe static extern void mono_unity_initialize_host_apis(delegate* unmanaged<nint, int, int> callback);
+    public unsafe static extern void mono_unity_initialize_host_apis(delegate* unmanaged<nint, int, nint, int, int> callback);
 }

--- a/unity/unity-embed-host/HostStructNative.cs
+++ b/unity/unity-embed-host/HostStructNative.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Unity.CoreCLRHelpers;
+
+/// <summary>
+/// Contains callbacks to native functions that are used by the managed code
+/// </summary>
+unsafe struct HostStructNative
+{
+    public delegate* unmanaged<byte*, void> unity_log;
+}


### PR DESCRIPTION
* Catch all exceptions.

* Use `unity_log` to log the exception.

These changes alone will not get exceptions into the player log.   A change to Unity is needed as well https://github.cds.internal.unity3d.com/unity/neutron/pull/62