### PR TITLE
Ensure that methods we get through MethodDesc are activated after load

### DIFF
--- a/src/coreclr/vm/mono/mono_coreclr.cpp
+++ b/src/coreclr/vm/mono/mono_coreclr.cpp
@@ -679,7 +679,7 @@ extern "C" EXPORT_API MonoMethod* EXPORT_CC mono_class_get_methods(MonoClass* kl
     CONTRACTL
     {
         THROWS;
-        GC_NOTRIGGER;
+        GC_TRIGGERS;
         PRECONDITION(klass != NULL);
     }
     CONTRACTL_END;
@@ -708,6 +708,7 @@ extern "C" EXPORT_API MonoMethod* EXPORT_CC mono_class_get_methods(MonoClass* kl
     }
 
     auto method = iterator->GetMethodDesc();
+    method->EnsureActive();
     iterator->Next();
     return (MonoMethod*)method;
 }


### PR DESCRIPTION
Fix CoreCLR debug build randomly failing on initial load.

By default, LoadAssembly loads assemblies up to "FILE_LOADED" state. Whenever we JIT or execute any method through normal means, CoreCLR ensures that required assemblies are activated in advance. However, when we get function pointers through MethodDesc, we avoid all activation points. 

>#21 0x007f69ef8667e6 in bool ScriptingInvocation::InvokeHandlingReturnValue<bool>(ScriptingExceptionPtr*, bool)
#22 0x007f69ef9b49cb in bool ScriptingInvocation::Invoke<bool>(ScriptingExceptionPtr*, bool)
#23 0x007f69ef745951 in bool ScriptingInvocation::Invoke<bool>()
#24 0x007f69ef74549a in Scripting::UnityEngine::ScriptingUtilityProxy::IsManagedCodeWorking(ScriptingExceptionPtr*)
#25 0x007f69ef745f81 in IsManagedCodeWorking()
#26 0x007f69ef743315 in MonoManager::LoadAssemblies(dynamic_bitset)
#27 0x007f69ef742fbe in MonoManager::BeginReloadAssembly(DomainReloadingData&)
#28 0x007f69ef8df65b in MonoManager::ReloadAssembly()
#29 0x007f69ef8df22c in MonoManager::AwakeFromLoad(AwakeFromLoadMode)
#30 0x007f69ef8df151 in AwakeFromLoadQueue::InvokePersistentManagerAwake(AwakeFromLoadQueue::Item*, unsigned int, AwakeFromLoadMode, bool)
#31 0x007f69ef88d746 in AwakeFromLoadQueue::PersistentManagerAwakeFromLoad(int, AwakeFromLoadMode, bool)
#32 0x007f69ef88e772 in AwakeFromLoadQueue::PersistentManagerAwakeFromLoad(ErrorsAndWarningsCapture*, bool)
#33 0x007f69ef88f439 in PersistentManager::IntegrateAllThreadedObjects()
#34 0x007f69ee1d94c0 in PersistentManager::LoadAndIntegrateAllPreallocatedObjects(PersistentManager::LockFlags)
#35 0x007f69edd24601 in PersistentManager::ReadObject(int, AwakeFromLoadMode)
#36 0x007f69edd73d20 in ReadObjectFromPersistentManager(int)
#37 0x007f69ee1e1cd9 in PPtr<Object>::operator Object*() const
#38 0x007f69ee1e1e85 in Object* dynamic_instanceID_cast<Object*>(int)
#39 0x007f69eec72e16 in LoadManager(core::basic_string<char, core::StringStorageDefault<char> > const&, int)
#40 0x007f69ef91328b in PlayerLoadGlobalManagers(char const*, char const*, unsigned int)
#41 0x00000000201102 in PlayerInitEngineGraphics(bool)
#42 0x007f69ebf84d90 in PlayerMain(int, char**)`


Assert failure(PID 204152 [0x00031d78], Thread: 204152 [0x31d78]): Consistency check failed: File has not had execution verifiedFAILED: m_bDisableActivationCheck || CheckLoadLevel(FILE_ACTIVE)
         FAILED: pDomainAssembly->CheckActivated()
                /home/bandures/coreclr/src/coreclr/vm/ceeload.cpp, line: 5043
        Managed code can only run when its module has been activated in the current app domain:  FAILED: pModule->CheckActivated()
                /home/bandures/coreclr/src/coreclr/vm/appdomain.cpp, line: 2537
         FAILED: GetAppDomain()->CheckCanExecuteManagedCode(pMD)
                /home/bandures/coreclr/src/coreclr/vm/prestub.cpp, line: 1903
    File: /home/bandures/coreclr/src/coreclr/vm/domainassembly.cpp Line: 291
    Image: /home/bandures/unity/~/player-save/Tests/EditModeAndPlayModeTests/Rendering/Meshes/PlayerWithTests.x86_64
