### PR TITLE
Minor clean up to `exception_from_name_msg`

### DIFF
--- a/unity/UnityEmbedHost.Generator/CoreCLRHostNativeWrappersGenerator.cs
+++ b/unity/UnityEmbedHost.Generator/CoreCLRHostNativeWrappersGenerator.cs
@@ -119,6 +119,8 @@ namespace Unity.CoreCLRHelpers;
 
         switch (typeSymbol.NativeWrapperTypeFor(providerAttributes))
         {
+            case "MonoException*":
+                return "Exception";
             case "MonoClass*":
             case "MonoType*":
                 return "Type";
@@ -186,6 +188,7 @@ namespace Unity.CoreCLRHelpers;
             case "MonoArray*":
             case "MonoReflectionMethod*":
             case "MonoReflectionField*":
+            case "MonoException*":
                 return ".ToManagedRepresentation()";
             case "MonoClass*":
                 return ".TypeFromHandleIntPtr()";
@@ -198,6 +201,8 @@ namespace Unity.CoreCLRHelpers;
     {
         switch (methodSymbol.NativeWrapperTypeForReturnType())
         {
+            case "MonoException*":
+                return "(Exception)";
             case "MonoArray*":
                 return "(Array)";
             case "MonoReflectionMethod*":

--- a/unity/UnityEmbedHost.Tests/BaseEmbeddingApiTests.cs
+++ b/unity/UnityEmbedHost.Tests/BaseEmbeddingApiTests.cs
@@ -59,9 +59,24 @@ public abstract class BaseEmbeddingApiTests
 
         fixed (byte* p = msg_bytes, n = name_bytes, ns = namespace_bytes)
         {
-            ex = (Exception)ClrHost.exception_from_name_msg(assembly, (sbyte*)ns, (sbyte*)n, (sbyte*)p).ToManagedRepresentation();
+            ex = ClrHost.exception_from_name_msg(assembly, (sbyte*)ns, (sbyte*)n, (sbyte*)p);
         }
-        Assert.That(msg, Is.EqualTo(ex.Message));
+        Assert.That(ex.Message, Is.EqualTo(msg));
+    }
+
+    [Test]
+    public unsafe void ExceptionFromClassWorksNullMessage()
+    {
+        byte[] name_bytes = "Exception"u8.ToArray();
+        byte[] namespace_bytes = "System"u8.ToArray();
+        Exception ex;
+        IntPtr assembly = ClrHost.class_get_image(typeof(Exception));
+
+        fixed (byte* n = name_bytes, ns = namespace_bytes)
+        {
+            ex = ClrHost.exception_from_name_msg(assembly, (sbyte*)ns, (sbyte*)n, null);
+        }
+        Assert.That(ex.Message, Is.EqualTo(string.Empty));
     }
 
 #pragma warning disable CS0612


### PR DESCRIPTION
I was taking a pass over the apis to add parameter validation, or not in the case of parameters that could be null, and noticed some clean up opportunities for 

* Add `MonoException*` to the source generators special case handling for more the C# friendly wrappers.

* Flip `Assert.That` parameters.  The syntax is `Assert.That(actual, Is.EqualTo(expected))`.  Having the parameters backwards still works for asserting but does lead to more confusing error messages if the test were to fail.

* Added a test for a null message.  