### PR TITLE
WIP : Parameter validation

### DIFF
--- a/unity/UnityEmbedHost.Tests/EmbeddingApiTests.cs
+++ b/unity/UnityEmbedHost.Tests/EmbeddingApiTests.cs
@@ -10,4 +10,101 @@ namespace UnityEmbedHost.Tests;
 public class EmbeddingApiTests : BaseEmbeddingApiTests
 {
     internal override ICoreCLRHostWrapper ClrHost { get; } = new CoreCLRHostWrappers();
+
+    [Test]
+    public unsafe void ClassFromNameNullImageThrows()
+    {
+        Assert.Throws<ArgumentNullException>(() => ClrHost.class_from_name(IntPtr.Zero, null, null, false));
+    }
+
+    [Test]
+    public unsafe void ClassFromNameNullNamespaceThrows()
+    {
+        var type = typeof(Animal);
+        Assert.Throws<ArgumentNullException>(() => ClrHost.class_from_name(ClrHost.class_get_image(type), null, null, false));
+    }
+
+
+    [Test]
+    public unsafe void ClassFromNameNullNameThrows()
+    {
+        var type = typeof(Animal);
+        byte[] @namespace = Encoding.UTF8.GetBytes(type.Namespace!);
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            fixed (byte* ns = @namespace)
+            {
+                ClrHost.class_from_name(ClrHost.class_get_image(type), (sbyte*)ns, null, false);
+            }
+        });
+    }
+
+    [Test]
+    public unsafe void ClassGetImageNullImageThrows()
+    {
+        Assert.Throws<ArgumentNullException>(() => ClrHost.class_get_image(null));
+    }
+
+    [Test]
+    public unsafe void ArrayLengthNullArrayThrows()
+    {
+        Assert.Throws<ArgumentNullException>(() => ClrHost.array_length(null));
+    }
+
+    [Test]
+    public unsafe void ArrayNewNullKlassThrows()
+    {
+        Assert.Throws<ArgumentNullException>(() => ClrHost.array_new(null, 0));
+    }
+
+    [Test]
+    public unsafe void AssemblyGetObjectNullAssemblyThrows()
+    {
+        Assert.Throws<ArgumentNullException>(() => ClrHost.assembly_get_object(IntPtr.Zero));
+    }
+
+    [Test]
+    public unsafe void AssemblyLoadedNullAssemblyNameThrows()
+    {
+        Assert.Throws<ArgumentNullException>(() => ClrHost.assembly_loaded(null));
+    }
+
+    [Test]
+    public unsafe void ExceptionFromNameMsgNullImageThrows()
+    {
+        Assert.Throws<ArgumentNullException>(() => ClrHost.exception_from_name_msg(IntPtr.Zero, null, null, null));
+    }
+
+    [Test]
+    public unsafe void ExceptionFromNameMsgNullNamespaceThrows()
+    {
+        var type = typeof(Animal);
+        Assert.Throws<ArgumentNullException>(() => ClrHost.exception_from_name_msg(ClrHost.class_get_image(type), null, null, null));
+    }
+
+    [Test]
+    public unsafe void ExceptionFromNameMsgNullNameThrows()
+    {
+        var type = typeof(Animal);
+        byte[] @namespace = Encoding.UTF8.GetBytes(type.Namespace!);
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            fixed (byte* ns = @namespace)
+            {
+                ClrHost.exception_from_name_msg(ClrHost.class_get_image(type), (sbyte*)ns, null, null);
+            }
+        });
+    }
+
+    [Test]
+    public void ObjectNewNullTypeThrows()
+    {
+        Assert.Throws<ArgumentNullException>(() => ClrHost.object_new(null));
+    }
+
+    [Test]
+    public void ValueBoxNullTypeThrows()
+    {
+        Assert.Throws<ArgumentNullException>(() => ClrHost.value_box(null, IntPtr.Zero));
+    }
 }

--- a/unity/unity-embed-host/CoreCLRHost.cs
+++ b/unity/unity-embed-host/CoreCLRHost.cs
@@ -95,6 +95,13 @@ static unsafe partial class CoreCLRHost
         [NativeCallbackType("const char*")] sbyte* name,
         bool ignoreCase)
     {
+        if (image == IntPtr.Zero)
+            throw new ArgumentNullException(nameof(image));
+        if (name_space == null)
+            throw new ArgumentNullException(nameof(name_space));
+        if (name == null)
+            throw new ArgumentNullException(nameof(name));
+
         Assembly assembly = image.AssemblyFromGCHandleIntPtr();
         var ns = new string(name_space);
         var klass_name = new string(name);
@@ -126,6 +133,8 @@ static unsafe partial class CoreCLRHost
     [return: NativeCallbackType("MonoImage*")]
     public static IntPtr class_get_image([NativeCallbackType("MonoClass*")] IntPtr klass)
     {
+        if (klass == IntPtr.Zero)
+            throw new ArgumentNullException(nameof(klass));
         var type = klass.TypeFromHandleIntPtr();
         return GetPairForAssembly(type.Assembly).handle;
     }
@@ -154,7 +163,11 @@ static unsafe partial class CoreCLRHost
 
     [return: NativeCallbackType("MonoAssembly*")]
     public static IntPtr assembly_loaded([NativeCallbackType("MonoAssemblyName*")] MonoAssemblyName* aname)
-        => image_loaded(aname->name);
+    {
+        if (aname == null)
+            throw new ArgumentNullException(nameof(aname));
+        return image_loaded(aname->name);
+    }
 
     [return: NativeCallbackType("MonoImage*")]
     [NativeFunction(NativeFunctionOptions.DoNotGenerate)]
@@ -253,7 +266,11 @@ static unsafe partial class CoreCLRHost
     [NativeFunction("coreclr_array_length")]
     [return: NativeCallbackType("int")]
     public static int array_length([NativeCallbackType("MonoArray*")] IntPtr array)
-        => ((Array)array.ToManagedRepresentation()).Length;
+    {
+        if (array == IntPtr.Zero)
+            throw new ArgumentNullException(nameof(array));
+        return ((Array)array.ToManagedRepresentation()).Length;
+    }
 
     [return: NativeCallbackType("MonoObject*")]
     public static IntPtr value_box(
@@ -364,7 +381,11 @@ static unsafe partial class CoreCLRHost
         IntPtr domain,
         [NativeCallbackType("MonoAssembly*")]
         IntPtr assembly)
-        => assembly.AssemblyFromGCHandleIntPtr().ToNativeRepresentation();
+    {
+        if (assembly == IntPtr.Zero)
+            throw new ArgumentNullException(nameof(assembly));
+        return assembly.AssemblyFromGCHandleIntPtr().ToNativeRepresentation();
+    }
 
     static void Log(string message)
     {


### PR DESCRIPTION
In https://github.com/Unity-Technologies/runtime/pull/183 it looked like there was a desire to add parameter validation.

I thought I would start tossing together changes to see what that would look like.   I did a few and thought I'd get feedback before continuing.  Here is what I've found so far.

* Github Copilot was able to generate some of the tests automatically.  Although it's not giving me much now after it's initial attempt.
* 1 or 2 apis already threw ArgumentNullException thanks to whatever helpers we use having their own argument validation.
* Some apis throw a NullReferenceException today.   Given that most methods have 1-3 parameters I suspect you could guess the culprit in many cases.
* Some apis have a message about an IntPtr.zero and then additional call stack info that would narrow down the culprit parameter.

@joncham @UnityAlex Is this worth completing and doing for all apis?  If it could make someone's life easier then I'm happy to finish it.  If these are going to be uncommonly encountered and you can often infer which parameter is the problem, then maybe this is a waste of time.