### PR TITLE
Restore GC safety of managed tests that call into native

### DIFF
--- a/unity/UnityEmbedHost.Tests/CoreCLRHostSetup.cs
+++ b/unity/UnityEmbedHost.Tests/CoreCLRHostSetup.cs
@@ -13,10 +13,13 @@ public class CoreCLRHostSetup
     [OneTimeSetUp]
     public void Initialize()
     {
+        // Need to use handles to ensure the managed tests that run through native are GC safe now that WorkaroundToGetGCSafety has been removed
+        var returnHandlesFromAPI = true;
 #if TESTING_UNITY_CORECLR
         CoreCLRHostNative.InitializeNative();
+        CoreCLRHost.OverrideNativeOptions(returnHandlesFromAPI: returnHandlesFromAPI);
 #else
-        CoreCLRHost.InitState();
+        CoreCLRHost.InitState(returnHandlesFromAPI: returnHandlesFromAPI);
 #endif
     }
 }

--- a/unity/unity-embed-host/HostStructNative.cs
+++ b/unity/unity-embed-host/HostStructNative.cs
@@ -9,6 +9,5 @@ namespace Unity.CoreCLRHelpers;
 unsafe struct HostStructNative
 {
     public delegate* unmanaged<byte*, void> unity_log;
-    public delegate* unmanaged<bool> use_real_gc;
     public delegate* unmanaged<bool> return_handles_from_api;
 }

--- a/unity/unity-embed-host/UnsafeExtensions.cs
+++ b/unity/unity-embed-host/UnsafeExtensions.cs
@@ -16,7 +16,6 @@ namespace Unity.CoreCLRHelpers;
 /// </summary>
 static class UnsafeExtensions
 {
-    private static readonly bool s_ReturnHandlesFromAPI = CoreCLRHost.UseRealGC() || CoreCLRHost.ReturnHandlesFromAPI();
     public static object ToManagedRepresentation(this nint intPtr)
     {
         var value = intPtr;
@@ -31,7 +30,7 @@ static class UnsafeExtensions
 
     public static nint ToNativeRepresentation(this object obj)
     {
-        if (s_ReturnHandlesFromAPI)
+        if (CoreCLRHost.ReturnHandlesFromAPI())
         {
             var handle = (nuint)(nint)(IntPtr)GCHandle.Alloc(obj);
             handle |= kHandleMask;


### PR DESCRIPTION
* Having `s_ReturnHandlesFromAPI` be a static variable populated by calling methods that would access a struct initialized from native was dicey since the native struct may or may not have been cached yet.

* Initialization of the two bool flags has been refactored to have better control over when we cache the values from native.

* Expose APIs to let the tests set the bool values used.  This is necessary for a few reasons. (1) During the managed only tests the native host struct is never available.  And (2) The tests need to use different values then the default.

* The managed tests now run with `returnHandlesFromAPI` = true.  This makes the managed tests that call into native GC safe again.  And this makes the managed only tests consistent.

* Simplify useRealGC.  This doesn't need to be plumbed into the managed side.