### PR TITLE
Add profiler init function which can be used at startup

### DIFF
--- a/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
+++ b/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
@@ -34,6 +34,7 @@ EXPORTS
         coreclr_array_length
         coreclr_class_from_systemtypeinstance
         coreclr_image_get_custom_attribute_data
+        coreclr_unity_profiler_register
         mono_add_internal_call
         mono_array_addr_with_size
         mono_array_class_get

--- a/src/coreclr/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/coreclr/dlls/mscoree/mscorwks_unixexports.src
@@ -20,6 +20,7 @@ mono_unity_initialize_host_apis
 coreclr_array_length
 coreclr_class_from_systemtypeinstance
 coreclr_image_get_custom_attribute_data
+coreclr_unity_profiler_register
 mono_add_internal_call
 mono_array_addr_with_size
 mono_array_class_get

--- a/src/coreclr/vm/mono/mono_coreclr.cpp
+++ b/src/coreclr/vm/mono/mono_coreclr.cpp
@@ -16,6 +16,7 @@
 #include "threadsuspend.h"
 #include "typeparse.h"
 #include "typestring.h"
+#include "profilepriv.h"
 
 #ifdef FEATURE_PAL
 #include "pal.h"
@@ -3146,4 +3147,15 @@ extern "C" EXPORT_API gboolean EXPORT_CC unity_mono_method_is_inflated_specific(
 {
     GCX_PREEMP(); // temporary until we sort out our GC thread model
     return g_HostStruct->unity_mono_method_is_inflated_specific(method, klass);
+}
+
+extern "C" EXPORT_API void EXPORT_CC coreclr_unity_profiler_register(const CLSID* classId, const guint16* profilerDllPathUtf16)
+{
+    STATIC_CONTRACT_NOTHROW;
+
+    StoredProfilerNode *profilerData = new StoredProfilerNode();
+    profilerData->guid = *classId;
+    profilerData->path.Set(reinterpret_cast<LPCWSTR>(profilerDllPathUtf16));
+
+    g_profControlBlock.storedProfilers.InsertHead(profilerData);
 }


### PR DESCRIPTION
The only way to attach to CoreCLR at startup is to use environment variables. 
This PR adds an integration function to specify profiler dll & class id directly, which is a cleaner way to initialize it.

```
       setenv("CORECLR_ENABLE_PROFILING", "1", 1);
       setenv("CORECLR_PROFILER", "{55A7EED1-7744-4C2C-A5D4-7FD66EF45AAE}", 1);
       setenv("CORECLR_PROFILER_PATH", profilerPath.c_str(), 1);
```

vs

```
        coreclr_unity_profiler_register((const CLSID*)&IID_ScriptingCoreClrProfiler, tmpPathStr.data());
```


