### PR TITLE
Added build job for win-arm64

### DIFF
--- a/.yamato/all-tests.yml
+++ b/.yamato/all-tests.yml
@@ -48,6 +48,7 @@ build_published:
   name: Build Published
   dependencies:
   - path: .yamato/build.yml#build_linux_x64_release
+  - path: .yamato/build.yml#build_windows_arm64_release
   - path: .yamato/build.yml#build_windows_x64_release
   - path: .yamato/build.yml#build_windows_x86_release
   - path: .yamato/build.yml#generate_osx_x64_arm64

--- a/.yamato/build.yml
+++ b/.yamato/build.yml
@@ -9,6 +9,8 @@ build_all:
   - path: .yamato/build.yml#build_osx_arm64_release
   - path: .yamato/build.yml#build_osx_x64_debug
   - path: .yamato/build.yml#build_osx_x64_release
+  - path: .yamato/build.yml#build_windows_arm64_debug
+  - path: .yamato/build.yml#build_windows_arm64_release
   - path: .yamato/build.yml#build_windows_x64_debug
   - path: .yamato/build.yml#build_windows_x64_release
   - path: .yamato/build.yml#build_windows_x86_debug
@@ -144,6 +146,48 @@ build_osx_x64_release:
   - ExcludeFromPublishing
   - MacOS
   - Release
+build_windows_arm64_debug:
+  name: Build Windows arm64 Debug
+  agent:
+    image: platform-foundation/coreclr-windows:v0.0.1-1276296
+    type: Unity::VM
+    flavor: b1.xlarge
+  commands:
+  - command: .yamato/scripts/build_yamato.cmd --arch=arm64 --config=Debug
+  artifacts:
+    7z-archives:
+      paths:
+      - artifacts\unity\**
+    build:
+      paths:
+      - artifacts\bin\**
+  variables:
+    ARTIFACT_FILENAME: dotnet-unity-windows-arm64.7z
+  labels:
+  - BuildJob
+  - Debug
+  - Windows
+build_windows_arm64_release:
+  name: Build Windows arm64 Release
+  agent:
+    image: platform-foundation/coreclr-windows:v0.0.1-1276296
+    type: Unity::VM
+    flavor: b1.xlarge
+  commands:
+  - command: .yamato/scripts/build_yamato.cmd --arch=arm64 --config=Release
+  artifacts:
+    7z-archives:
+      paths:
+      - artifacts\unity\**
+    build:
+      paths:
+      - artifacts\bin\**
+  variables:
+    ARTIFACT_FILENAME: dotnet-unity-windows-arm64.7z
+  labels:
+  - BuildJob
+  - Release
+  - Windows
 build_windows_x64_debug:
   name: Build Windows x64 Debug
   agent:

--- a/.yamato/class-library-tests.yml
+++ b/.yamato/class-library-tests.yml
@@ -9,6 +9,8 @@ all_class_library_tests:
   - path: .yamato/class-library-tests.yml#test_-_class_library_-_osx_arm64_release
   - path: .yamato/class-library-tests.yml#test_-_class_library_-_osx_x64_debug
   - path: .yamato/class-library-tests.yml#test_-_class_library_-_osx_x64_release
+  - path: .yamato/class-library-tests.yml#test_-_class_library_-_windows_arm64_debug
+  - path: .yamato/class-library-tests.yml#test_-_class_library_-_windows_arm64_release
   - path: .yamato/class-library-tests.yml#test_-_class_library_-_windows_x64_debug
   - path: .yamato/class-library-tests.yml#test_-_class_library_-_windows_x64_release
   - path: .yamato/class-library-tests.yml#test_-_class_library_-_windows_x86_debug
@@ -50,7 +52,9 @@ test_-_class_library_-_osx_arm64_debug:
   dependencies:
   - path: .yamato/build.yml#build_osx_arm64_debug
   labels:
+  - ExcludeFromTesting
   - MacOS
+  - TestJob
 test_-_class_library_-_osx_arm64_release:
   name: Test - Class Library - OSX arm64 Release
   agent:
@@ -62,7 +66,9 @@ test_-_class_library_-_osx_arm64_release:
   dependencies:
   - path: .yamato/build.yml#build_osx_arm64_release
   labels:
+  - ExcludeFromTesting
   - MacOS
+  - TestJob
 test_-_class_library_-_osx_x64_debug:
   name: Test - Class Library - OSX x64 Debug
   agent:
@@ -89,6 +95,34 @@ test_-_class_library_-_osx_x64_release:
   labels:
   - MacOS
   - TestJob
+test_-_class_library_-_windows_arm64_debug:
+  name: Test - Class Library - Windows arm64 Debug
+  agent:
+    image: platform-foundation/coreclr-windows:v0.0.1-1276296
+    type: Unity::VM
+    flavor: b1.xlarge
+  commands:
+  - command: .yamato/scripts/build_yamato.cmd --arch=arm64 --config=Debug --test=classlibs
+  dependencies:
+  - path: .yamato/build.yml#build_windows_arm64_debug
+  labels:
+  - ExcludeFromTesting
+  - TestJob
+  - Windows
+test_-_class_library_-_windows_arm64_release:
+  name: Test - Class Library - Windows arm64 Release
+  agent:
+    image: platform-foundation/coreclr-windows:v0.0.1-1276296
+    type: Unity::VM
+    flavor: b1.xlarge
+  commands:
+  - command: .yamato/scripts/build_yamato.cmd --arch=arm64 --config=Release --test=classlibs
+  dependencies:
+  - path: .yamato/build.yml#build_windows_arm64_release
+  labels:
+  - ExcludeFromTesting
+  - TestJob
+  - Windows
 test_-_class_library_-_windows_x64_debug:
   name: Test - Class Library - Windows x64 Debug
   agent:

--- a/.yamato/embedding-tests.yml
+++ b/.yamato/embedding-tests.yml
@@ -9,6 +9,8 @@ all_embedding_api_tests:
   - path: .yamato/embedding-tests.yml#test_-_embedding_api_-_osx_arm64_release
   - path: .yamato/embedding-tests.yml#test_-_embedding_api_-_osx_x64_debug
   - path: .yamato/embedding-tests.yml#test_-_embedding_api_-_osx_x64_release
+  - path: .yamato/embedding-tests.yml#test_-_embedding_api_-_windows_arm64_debug
+  - path: .yamato/embedding-tests.yml#test_-_embedding_api_-_windows_arm64_release
   - path: .yamato/embedding-tests.yml#test_-_embedding_api_-_windows_x64_debug
   - path: .yamato/embedding-tests.yml#test_-_embedding_api_-_windows_x64_release
   - path: .yamato/embedding-tests.yml#test_-_embedding_api_-_windows_x86_debug
@@ -50,7 +52,9 @@ test_-_embedding_api_-_osx_arm64_debug:
   dependencies:
   - path: .yamato/build.yml#build_osx_arm64_debug
   labels:
+  - ExcludeFromTesting
   - MacOS
+  - TestJob
 test_-_embedding_api_-_osx_arm64_release:
   name: Test - Embedding API - OSX arm64 Release
   agent:
@@ -62,7 +66,9 @@ test_-_embedding_api_-_osx_arm64_release:
   dependencies:
   - path: .yamato/build.yml#build_osx_arm64_release
   labels:
+  - ExcludeFromTesting
   - MacOS
+  - TestJob
 test_-_embedding_api_-_osx_x64_debug:
   name: Test - Embedding API - OSX x64 Debug
   agent:
@@ -89,6 +95,34 @@ test_-_embedding_api_-_osx_x64_release:
   labels:
   - MacOS
   - TestJob
+test_-_embedding_api_-_windows_arm64_debug:
+  name: Test - Embedding API - Windows arm64 Debug
+  agent:
+    image: platform-foundation/coreclr-windows:v0.0.1-1276296
+    type: Unity::VM
+    flavor: b1.xlarge
+  commands:
+  - command: .yamato/scripts/build_yamato.cmd --arch=arm64 --config=Debug --test=embedding
+  dependencies:
+  - path: .yamato/build.yml#build_windows_arm64_debug
+  labels:
+  - ExcludeFromTesting
+  - TestJob
+  - Windows
+test_-_embedding_api_-_windows_arm64_release:
+  name: Test - Embedding API - Windows arm64 Release
+  agent:
+    image: platform-foundation/coreclr-windows:v0.0.1-1276296
+    type: Unity::VM
+    flavor: b1.xlarge
+  commands:
+  - command: .yamato/scripts/build_yamato.cmd --arch=arm64 --config=Release --test=embedding
+  dependencies:
+  - path: .yamato/build.yml#build_windows_arm64_release
+  labels:
+  - ExcludeFromTesting
+  - TestJob
+  - Windows
 test_-_embedding_api_-_windows_x64_debug:
   name: Test - Embedding API - Windows x64 Debug
   agent:

--- a/.yamato/runtime-and-pal-tests.yml
+++ b/.yamato/runtime-and-pal-tests.yml
@@ -9,6 +9,8 @@ all_runtime__pal_tests:
   - path: .yamato/runtime-and-pal-tests.yml#test_-_runtime__pal_-_osx_arm64_release
   - path: .yamato/runtime-and-pal-tests.yml#test_-_runtime__pal_-_osx_x64_debug
   - path: .yamato/runtime-and-pal-tests.yml#test_-_runtime__pal_-_osx_x64_release
+  - path: .yamato/runtime-and-pal-tests.yml#test_-_runtime__pal_-_windows_arm64_debug
+  - path: .yamato/runtime-and-pal-tests.yml#test_-_runtime__pal_-_windows_arm64_release
   - path: .yamato/runtime-and-pal-tests.yml#test_-_runtime__pal_-_windows_x64_debug
   - path: .yamato/runtime-and-pal-tests.yml#test_-_runtime__pal_-_windows_x64_release
   - path: .yamato/runtime-and-pal-tests.yml#test_-_runtime__pal_-_windows_x86_debug
@@ -50,7 +52,9 @@ test_-_runtime__pal_-_osx_arm64_debug:
   dependencies:
   - path: .yamato/build.yml#build_osx_arm64_debug
   labels:
+  - ExcludeFromTesting
   - MacOS
+  - TestJob
 test_-_runtime__pal_-_osx_arm64_release:
   name: Test - Runtime & Pal - OSX arm64 Release
   agent:
@@ -62,7 +66,9 @@ test_-_runtime__pal_-_osx_arm64_release:
   dependencies:
   - path: .yamato/build.yml#build_osx_arm64_release
   labels:
+  - ExcludeFromTesting
   - MacOS
+  - TestJob
 test_-_runtime__pal_-_osx_x64_debug:
   name: Test - Runtime & Pal - OSX x64 Debug
   agent:
@@ -89,6 +95,34 @@ test_-_runtime__pal_-_osx_x64_release:
   labels:
   - MacOS
   - TestJob
+test_-_runtime__pal_-_windows_arm64_debug:
+  name: Test - Runtime & Pal - Windows arm64 Debug
+  agent:
+    image: platform-foundation/coreclr-windows:v0.0.1-1276296
+    type: Unity::VM
+    flavor: b1.xlarge
+  commands:
+  - command: .yamato/scripts/build_yamato.cmd --arch=arm64 --config=Debug --test=runtime,pal
+  dependencies:
+  - path: .yamato/build.yml#build_windows_arm64_debug
+  labels:
+  - ExcludeFromTesting
+  - TestJob
+  - Windows
+test_-_runtime__pal_-_windows_arm64_release:
+  name: Test - Runtime & Pal - Windows arm64 Release
+  agent:
+    image: platform-foundation/coreclr-windows:v0.0.1-1276296
+    type: Unity::VM
+    flavor: b1.xlarge
+  commands:
+  - command: .yamato/scripts/build_yamato.cmd --arch=arm64 --config=Release --test=runtime,pal
+  dependencies:
+  - path: .yamato/build.yml#build_windows_arm64_release
+  labels:
+  - ExcludeFromTesting
+  - TestJob
+  - Windows
 test_-_runtime__pal_-_windows_x64_debug:
   name: Test - Runtime & Pal - Windows x64 Debug
   agent:

--- a/unity/CITools/Unity.Cookbook/Data.cs
+++ b/unity/CITools/Unity.Cookbook/Data.cs
@@ -17,12 +17,18 @@ static class Data
             new JobConfiguration {SystemType = SystemType.Windows, Architecture = Architecture.x86, Configuration = Configuration.Debug},
             new JobConfiguration {SystemType = SystemType.Windows, Architecture = Architecture.x86, Configuration = Configuration.Release},
 
+            // The Windows arm64 tests do not have agents to be executed on.
+            new JobConfiguration {SystemType = SystemType.Windows, Architecture = Architecture.arm64, Configuration = Configuration.Debug, ExcludeFromTesting =  true},
+            new JobConfiguration {SystemType = SystemType.Windows, Architecture = Architecture.arm64, Configuration = Configuration.Release, ExcludeFromTesting =  true},
+
             // macOS
+            // x64 and arm64 artifacts are published as a part of combined x64arm64 fat build job.
             new JobConfiguration {SystemType = SystemType.MacOS, Architecture = Architecture.x64, Configuration = Configuration.Debug, ExcludeFromPublishing =  true},
             new JobConfiguration {SystemType = SystemType.MacOS, Architecture = Architecture.x64, Configuration = Configuration.Release, ExcludeFromPublishing =  true},
 
-            new JobConfiguration {SystemType = SystemType.MacOS, Architecture = Architecture.arm64, Configuration = Configuration.Debug, ExcludeFromPublishing =  true},
-            new JobConfiguration {SystemType = SystemType.MacOS, Architecture = Architecture.arm64, Configuration = Configuration.Release, ExcludeFromPublishing =  true},
+            // The arm64 tests are currently broken and should not be included by the top level test jobs.
+            new JobConfiguration {SystemType = SystemType.MacOS, Architecture = Architecture.arm64, Configuration = Configuration.Debug, ExcludeFromPublishing =  true, ExcludeFromTesting =  true},
+            new JobConfiguration {SystemType = SystemType.MacOS, Architecture = Architecture.arm64, Configuration = Configuration.Release, ExcludeFromPublishing =  true, ExcludeFromTesting =  true},
 
             // Linux
             new JobConfiguration {SystemType = SystemType.Ubuntu, Architecture = Architecture.x64, Configuration = Configuration.Debug},

--- a/unity/CITools/Unity.Cookbook/GroupingTag.cs
+++ b/unity/CITools/Unity.Cookbook/GroupingTag.cs
@@ -8,4 +8,5 @@ static class GroupingTag
     public const string TestJob = "TestJob";
     public const string BuildJob = "BuildJob";
     public const string ExcludeFromPublishing = "ExcludeFromPublishing";
+    public const string ExcludeFromTesting = "ExcludeFromTesting";
 }

--- a/unity/CITools/Unity.Cookbook/JobConfiguration.cs
+++ b/unity/CITools/Unity.Cookbook/JobConfiguration.cs
@@ -11,5 +11,14 @@ public class JobConfiguration
     public required Architecture Architecture;
     public required Configuration Configuration;
 
+    /// <summary>
+    /// Excludes configuration from automatic publishing of artifacts to stevedore.
+    /// E.g. if we want to do postprocessing of configuration artifacts in another job.
+    /// </summary>
     public bool ExcludeFromPublishing;
+
+    /// <summary>
+    /// Excludes configuration from being tested as a part of "All CoreCLR Tests" job.
+    /// </summary>
+    public bool ExcludeFromTesting;
 }

--- a/unity/CITools/Unity.Cookbook/Recipes/AllTests.cs
+++ b/unity/CITools/Unity.Cookbook/Recipes/AllTests.cs
@@ -54,7 +54,16 @@ public class AllTests : AggregateRecipeBase
     {
         return JobBuilder.Create(jobName)
             .WithDependencies(_finder
-                .FindByTags(GroupingTag.TestJob, platformTag))
+                .Find(job =>
+                {
+                    if (!job.Tags.Contains(GroupingTag.TestJob) || !job.Tags.Contains(platformTag))
+                        return false;
+
+                    if (job.Tags.Contains(GroupingTag.ExcludeFromTesting))
+                        return false;
+
+                    return true;
+                }))
             .Build();
     }
 


### PR DESCRIPTION
Added `Build Windows Arm64 Debug` and `Build Windows Arm64 Release` build jobs.
Added `dotnet-unity-windows-arm64.7z` to publishing
Added `ExcludeFromTesting` parameter to job configuration to exclude arm platforms from testing (as we need to update platform images)