### PR TITLE
Restore mono_runtime_invoke

### DIFF
--- a/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
+++ b/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
@@ -85,6 +85,7 @@ EXPORTS
         mono_method_signature
         mono_property_get_get_method
         mono_raise_exception
+        mono_runtime_invoke
         mono_runtime_invoke_with_nested_object
         mono_set_assemblies_path
         mono_set_assemblies_path_null_separated

--- a/src/coreclr/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/coreclr/dlls/mscoree/mscorwks_unixexports.src
@@ -72,6 +72,7 @@ mono_method_get_name
 mono_method_signature
 mono_property_get_get_method
 mono_raise_exception
+mono_runtime_invoke
 mono_runtime_invoke_with_nested_object
 mono_set_assemblies_path
 mono_set_assemblies_path_null_separated

--- a/src/coreclr/vm/mono/mono_coreclr.cpp
+++ b/src/coreclr/vm/mono/mono_coreclr.cpp
@@ -1191,6 +1191,20 @@ extern "C" EXPORT_API void EXPORT_CC mono_raise_exception(MonoException *ex)
     ASSERT_NOT_IMPLEMENTED;
 }
 
+extern "C" EXPORT_API MonoObject* EXPORT_CC mono_runtime_invoke(MonoMethod *method, void *obj, void **params, MonoException **exc)
+{
+    TRACE_API("%p, %p, %p, %p", method, obj, params, exc);
+
+    if (obj == nullptr)
+        return mono_runtime_invoke_with_nested_object(method, nullptr, nullptr, params, exc);
+    MonoClass_clr * klass = (MonoClass_clr*)reinterpret_cast<MonoObject_clr*>(obj)->GetMethodTable();
+    auto method_clr = (MonoMethod_clr*)method;
+    if (klass->IsValueType())// && !method_clr->IsVtableMethod())
+        return mono_runtime_invoke_with_nested_object(method, (char*)obj + sizeof(Object), obj, params, exc);
+    else
+        return mono_runtime_invoke_with_nested_object(method, obj, obj, params, exc);
+}
+
 extern "C" EXPORT_API MonoObject* EXPORT_CC mono_runtime_invoke_with_nested_object(MonoMethod *method, void *obj, void *parentobj, void **params, MonoException **exc)
 {
     TRACE_API("%p, %p, %p, %p, %p", method, obj, parentobj, params, exc);

--- a/unity/unity-sources/Runtime/Mono/MonoFunctions.h
+++ b/unity/unity-sources/Runtime/Mono/MonoFunctions.h
@@ -15,6 +15,7 @@ DO_API(gboolean, mono_unity_class_has_failure, (MonoClass * klass))
 DO_API(void, mono_add_internal_call, (const char *name, gconstpointer method))
 DO_API(MonoDomain*, mono_jit_init_version, (const char *file, const char* runtime_version))
 
+DO_API(MonoObject*, mono_runtime_invoke, (MonoMethod * method, void *obj, void **params, MonoException **exc))
 DO_API(int, mono_field_get_offset, (MonoClassField * field))
 DO_API(MonoClassField*, mono_class_get_fields, (MonoClass * klass, gpointer * iter))
 DO_API(MonoClass*, mono_class_get_nested_types, (MonoClass * klass, gpointer * iter))


### PR DESCRIPTION
This method was removed in:

https://github.com/Unity-Technologies/runtime/pull/228

along with the unity-embed-host removal, since it used the `mono_object_class_get` method, which was itself removed. However, this method is still used in a few places on the Unity side, so this change adds it back it, but with an implementation of `mono_object_class_get` that does not require the unity-embed-host.