### PR TITLE
Export a new method to initialize the domain

### DIFF
--- a/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
+++ b/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
@@ -77,6 +77,7 @@ EXPORTS
         mono_jit_info_table_find
         mono_jit_init
         mono_jit_init_version
+        coreclr_initialize_domain
         mono_metadata_signature_equal
         mono_metadata_type_equal
         mono_method_full_name

--- a/src/coreclr/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/coreclr/dlls/mscoree/mscorwks_unixexports.src
@@ -63,6 +63,7 @@ mono_is_debugger_attached
 mono_jit_info_table_find
 mono_jit_init
 mono_jit_init_version
+coreclr_initialize_domain
 mono_jit_parse_options
 mono_metadata_signature_equal
 mono_metadata_type_equal

--- a/src/coreclr/vm/mono/mono_coreclr.cpp
+++ b/src/coreclr/vm/mono/mono_coreclr.cpp
@@ -945,6 +945,20 @@ void list_tpa(const SString& searchPath, SString& tpa)
     }
 }
 
+extern "C" EXPORT_API void EXPORT_CC coreclr_initialize_domain(void* runtimeHost, unsigned int rootDomainId)
+{
+    AppDomain *pCurDomain = SystemDomain::GetCurrentDomain();
+
+    // Disable Windows message processing during waits
+    // On Windows by default waits will processing some messages (COM, WM_PAINT, ...) leading to reentrancy issues
+    pCurDomain->SetForceTrivialWaitOperations();
+
+    gRootDomain = gCurrentDomain = (MonoDomain*)pCurDomain;
+
+    g_CLRRuntimeHost = (ICLRRuntimeHost*)runtimeHost;
+    g_RootDomainId = rootDomainId;
+}
+
 extern "C" EXPORT_API MonoDomain* EXPORT_CC mono_jit_init_version(const char *file, const char* runtime_version)
 {
     gboolean useRealGC = false;


### PR DESCRIPTION
In order to move the CoreCLR initialization over to Unity, we need a new API method to initialize the domain internally in CoreCLR. This method does the minimum necessary to accomplish that.