### PR TITLE
Remove the Mono initialization method

### DIFF
--- a/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
+++ b/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
@@ -64,8 +64,6 @@ EXPORTS
         mono_image_get_table_rows
         mono_is_debugger_attached
         mono_jit_info_table_find
-        mono_jit_init
-        mono_jit_init_version
         coreclr_initialize_domain
         mono_metadata_signature_equal
         mono_metadata_type_equal

--- a/src/coreclr/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/coreclr/dlls/mscoree/mscorwks_unixexports.src
@@ -50,8 +50,6 @@ mono_gc_collect
 mono_image_get_table_rows
 mono_is_debugger_attached
 mono_jit_info_table_find
-mono_jit_init
-mono_jit_init_version
 coreclr_initialize_domain
 mono_metadata_signature_equal
 mono_metadata_type_equal

--- a/unity/unity-sources/Runtime/Mono/MonoFunctions.h
+++ b/unity/unity-sources/Runtime/Mono/MonoFunctions.h
@@ -13,7 +13,6 @@ typedef UNUSED_SYMBOL void(*MonoUnityExceptionFunc) (MonoObject* exc);
 DO_API(gboolean, mono_unity_class_has_failure, (MonoClass * klass))
 
 DO_API(void, mono_add_internal_call, (const char *name, gconstpointer method))
-DO_API(MonoDomain*, mono_jit_init_version, (const char *file, const char* runtime_version))
 
 DO_API(MonoObject*, mono_runtime_invoke, (MonoMethod * method, void *obj, void **params, MonoException **exc))
 DO_API(int, mono_field_get_offset, (MonoClassField * field))


### PR DESCRIPTION
Now that the Unity code calls `coreclr_initialize` directly, we don't need this method and the methods it calls any more, so remove them.

This completes https://jira.unity3d.com/browse/VM-2210.