### PR TITLE
Add back a function

### DIFF
--- a/src/native/public/mono/metadata/details/mono-debug-functions.h
+++ b/src/native/public/mono/metadata/details/mono-debug-functions.h
@@ -9,6 +9,7 @@
 MONO_API_FUNCTION(mono_bool, mono_debug_enabled, (void))
 
 MONO_API_FUNCTION(void, mono_debug_init, (MonoDebugFormat format))
+MONO_API_FUNCTION(void, mono_debug_open_image_from_memory, (MonoImage *image, const mono_byte *raw_contents, int size))
 MONO_API_FUNCTION(MONO_RT_EXTERNAL_ONLY void, mono_debug_cleanup, (void))
 
 MONO_API_FUNCTION(void, mono_debug_close_image, (MonoImage *image))


### PR DESCRIPTION
This was accidentally removed with https://github.com/Unity-Technologies/runtime/commit/9e2c0f36529ab724fb2dc22bb30f609ea1c61062#diff-836246b932c35d76cffca45b16dac2a63d6a3dae5aab1a6d376dd99dfe5af2a7