### PR TITLE
Remove unused functions

### DIFF
--- a/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
+++ b/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
@@ -63,8 +63,6 @@ EXPORTS
         mono_method_get_name
         mono_method_signature
         mono_runtime_invoke
-        mono_set_assemblies_path
-        mono_set_assemblies_path_null_separated
         mono_signature_get_param_count
         mono_signature_get_params
         mono_signature_get_return_type

--- a/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
+++ b/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
@@ -65,7 +65,6 @@ EXPORTS
         mono_runtime_invoke
         mono_set_assemblies_path
         mono_set_assemblies_path_null_separated
-        mono_set_dirs
         mono_signature_get_param_count
         mono_signature_get_params
         mono_signature_get_return_type

--- a/src/coreclr/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/coreclr/dlls/mscoree/mscorwks_unixexports.src
@@ -51,7 +51,6 @@ mono_method_signature
 mono_runtime_invoke
 mono_set_assemblies_path
 mono_set_assemblies_path_null_separated
-mono_set_dirs
 mono_signature_get_param_count
 mono_signature_get_params
 mono_signature_get_return_type

--- a/src/coreclr/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/coreclr/dlls/mscoree/mscorwks_unixexports.src
@@ -49,8 +49,6 @@ mono_method_get_last_managed
 mono_method_get_name
 mono_method_signature
 mono_runtime_invoke
-mono_set_assemblies_path
-mono_set_assemblies_path_null_separated
 mono_signature_get_param_count
 mono_signature_get_params
 mono_signature_get_return_type

--- a/src/coreclr/vm/mono/mono_coreclr.cpp
+++ b/src/coreclr/vm/mono/mono_coreclr.cpp
@@ -91,8 +91,6 @@ thread_local MonoDomain *gCurrentDomain = NULL;
 MonoDomain *gRootDomain = NULL;
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 
-static SString* s_AssemblyDir;
-static SString* s_EtcDir;
 static SString* s_AssemblyPaths;
 
 #define ASSERT_NOT_IMPLEMENTED printf("Function not implemented: %s\n", __func__);
@@ -818,12 +816,6 @@ extern "C" EXPORT_API void EXPORT_CC mono_set_assemblies_path_null_separated (co
         s_AssemblyPaths->AppendUTF8(PATH_SEPARATOR);
         name += l+1;
     }
-}
-
-extern "C" EXPORT_API void EXPORT_CC mono_set_dirs(const char *assembly_dir, const char *config_dir)
-{
-    s_AssemblyDir = new SString(SString::Utf8, assembly_dir);
-    s_EtcDir = new SString(SString::Utf8, config_dir);
 }
 
 extern "C" EXPORT_API guint32 EXPORT_CC mono_signature_get_param_count(MonoMethodSignature *sig)

--- a/src/coreclr/vm/mono/mono_coreclr.cpp
+++ b/src/coreclr/vm/mono/mono_coreclr.cpp
@@ -91,8 +91,6 @@ thread_local MonoDomain *gCurrentDomain = NULL;
 MonoDomain *gRootDomain = NULL;
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 
-static SString* s_AssemblyPaths;
-
 #define ASSERT_NOT_IMPLEMENTED printf("Function not implemented: %s\n", __func__);
 
 #define FIELD_ATTRIBUTE_PRIVATE               0x0001
@@ -799,23 +797,6 @@ MonoObject* EXPORT_CC mono_runtime_invoke_with_nested_object(MonoMethod *method,
             break;
     }
     return nullptr;
-}
-
-extern "C" EXPORT_API void EXPORT_CC mono_set_assemblies_path(const char* name)
-{
-    s_AssemblyPaths = new SString(SString::Utf8, name);
-}
-
-extern "C" EXPORT_API void EXPORT_CC mono_set_assemblies_path_null_separated (const char* name)
-{
-    s_AssemblyPaths = new SString();
-    while (*name != NULL)
-    {
-        size_t l = strlen(name);
-        s_AssemblyPaths->AppendUTF8(name);
-        s_AssemblyPaths->AppendUTF8(PATH_SEPARATOR);
-        name += l+1;
-    }
 }
 
 extern "C" EXPORT_API guint32 EXPORT_CC mono_signature_get_param_count(MonoMethodSignature *sig)

--- a/unity/unity-sources/Runtime/Mono/MonoFunctions.h
+++ b/unity/unity-sources/Runtime/Mono/MonoFunctions.h
@@ -79,8 +79,6 @@ DO_API(MonoClass*, mono_class_from_mono_type, (MonoType * image))
 
 DO_API(int, mono_array_element_size, (MonoClass * classOfArray))
 
-DO_API(void, mono_set_dirs, (const char *assembly_dir, const char *config_dir))
-
 DO_API(MonoException*, mono_unity_loader_get_last_error_and_error_prepare_exception, (void))
 
 #ifdef WIN32

--- a/unity/unity-sources/Runtime/Mono/MonoFunctions.h
+++ b/unity/unity-sources/Runtime/Mono/MonoFunctions.h
@@ -70,8 +70,6 @@ DO_API(gboolean, mono_metadata_signature_equal, (MonoMethodSignature * sig1, Mon
 DO_API(char, mono_signature_is_instance, (MonoMethodSignature * signature))
 DO_API(MonoMethod*, mono_method_get_last_managed, ())
 
-DO_API(void, mono_set_assemblies_path_null_separated, (const char* name))
-
 DO_API(gint32, mono_class_instance_size, (MonoClass * klass))
 DO_API(guint32, mono_class_get_type_token, (MonoClass * klass))
 DO_API(MonoProperty*, mono_class_get_property_from_name, (MonoClass * klass, const char *name))


### PR DESCRIPTION
Remove `mono_set_assemblies_path`, `mono_set_assemblies_path_null_separated`, and `mono_set_dirs`.