### PR TITLE
Remove artifactory dependency from buildscripts

### DIFF
--- a/.yamato/scripts/build_yamato.cmd
+++ b/.yamato/scripts/build_yamato.cmd
@@ -1,4 +1,4 @@
 @echo off
 
-call %~dp0../../dotnet.cmd restore %~dp0../../unity/CITools/BuildDriver/BuildDriver.csproj --configfile %~dp0../../unity/CITools/builddriver-nuget.config --
+call %~dp0../../dotnet.cmd restore %~dp0../../unity/CITools/BuildDriver/BuildDriver.csproj --configfile %~dp0../../NuGet.config
 call %~dp0../../dotnet.cmd run --project %~dp0../../unity/CITools/BuildDriver/BuildDriver.csproj --no-restore -- %*

--- a/.yamato/scripts/build_yamato.cmd
+++ b/.yamato/scripts/build_yamato.cmd
@@ -1,3 +1,4 @@
 @echo off
 
-%~dp0../../dotnet.cmd run --project %~dp0../../unity/CITools/BuildDriver/BuildDriver.csproj -- %*
+call %~dp0../../dotnet.cmd restore %~dp0../../unity/CITools/BuildDriver/BuildDriver.csproj --configfile %~dp0../../unity/CITools/builddriver-nuget.config --
+call %~dp0../../dotnet.cmd run --project %~dp0../../unity/CITools/BuildDriver/BuildDriver.csproj --no-restore -- %*

--- a/.yamato/scripts/build_yamato.sh
+++ b/.yamato/scripts/build_yamato.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 BASEDIR=$(dirname $0)
-$BASEDIR/../../dotnet.sh restore $BASEDIR/../../unity/CITools/BuildDriver/BuildDriver.csproj --configfile $BASEDIR/../../unity/CITools/builddriver-nuget.config
+$BASEDIR/../../dotnet.sh restore $BASEDIR/../../unity/CITools/BuildDriver/BuildDriver.csproj --configfile $BASEDIR/../../NuGet.config
 $BASEDIR/../../dotnet.sh run --project $BASEDIR/../../unity/CITools/BuildDriver/BuildDriver.csproj --no-restore -- "$@"

--- a/.yamato/scripts/build_yamato.sh
+++ b/.yamato/scripts/build_yamato.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
 BASEDIR=$(dirname $0)
-$BASEDIR/../../dotnet.sh run --project $BASEDIR/../../unity/CITools/BuildDriver/BuildDriver.csproj -- "$@"
+$BASEDIR/../../dotnet.sh restore $BASEDIR/../../unity/CITools/BuildDriver/BuildDriver.csproj --configfile $BASEDIR/../../unity/CITools/builddriver-nuget.config
+$BASEDIR/../../dotnet.sh run --project $BASEDIR/../../unity/CITools/BuildDriver/BuildDriver.csproj --no-restore -- "$@"

--- a/unity/CITools/builddriver-nuget.config
+++ b/unity/CITools/builddriver-nuget.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-	<packageSources>
-		<add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
-	</packageSources>
-</configuration>

--- a/unity/CITools/builddriver-nuget.config
+++ b/unity/CITools/builddriver-nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+	<packageSources>
+		<add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
+	</packageSources>
+</configuration>


### PR DESCRIPTION
I tried building on a desktop not connected to VPN to ensure source code customers could build. I ran into an issue where the build tried contacting artifactory. I think there's some fighting to restore dependencies, so I changed the build_yamato scripts to use the Microsoft nuget file to restore project dependencies, as we only need to contact artifactory for CI.