### PR TITLE
Add function to turn concurrent GC on/off

### DIFF
--- a/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
+++ b/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
@@ -32,6 +32,7 @@ EXPORTS
         ; mono
         coreclr_image_get_custom_attribute_data
         coreclr_unity_profiler_register
+        coreclr_unity_gc_concurrent_mode
         mono_array_element_size
         mono_assembly_get_assemblyref
         mono_assembly_get_image

--- a/src/coreclr/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/coreclr/dlls/mscoree/mscorwks_unixexports.src
@@ -18,6 +18,7 @@ MetaDataGetDispenser
 ; mono
 coreclr_image_get_custom_attribute_data
 coreclr_unity_profiler_register
+coreclr_unity_gc_concurrent_mode
 mono_array_element_size
 mono_assembly_get_assemblyref
 mono_assembly_get_image


### PR DESCRIPTION
We need a way to disable Concurrent GC dynamically, so we can enable expensive profiling flags dynamically in runtime.
At the moment, there is no embedding API for that, so this warrants this PR.

It adds a function that can turn concurrent GC on/off.
I've tested it with FPSSample and running it seems to be working.
I've set WaitUntilConcurrentGCCompleteAsync to INIFINTE, which is the default value if this function is called when profiler attachment is happening. If this is a problem, an additional function parameter can be introduced. 