### PR TITLE
Exposed coreclr_unity_profiler_get_managed_assembly_load_context API

### DIFF
--- a/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
+++ b/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
@@ -32,6 +32,7 @@ EXPORTS
         ; mono
         coreclr_image_get_custom_attribute_data
         coreclr_unity_profiler_register
+        coreclr_unity_profiler_get_managed_assembly_load_context
         coreclr_unity_gc_concurrent_mode
         mono_array_element_size
         mono_assembly_get_assemblyref

--- a/src/coreclr/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/coreclr/dlls/mscoree/mscorwks_unixexports.src
@@ -18,6 +18,7 @@ MetaDataGetDispenser
 ; mono
 coreclr_image_get_custom_attribute_data
 coreclr_unity_profiler_register
+coreclr_unity_profiler_get_managed_assembly_load_context
 coreclr_unity_gc_concurrent_mode
 mono_array_element_size
 mono_assembly_get_assemblyref

--- a/src/coreclr/vm/mono/mono_coreclr.cpp
+++ b/src/coreclr/vm/mono/mono_coreclr.cpp
@@ -912,6 +912,22 @@ extern "C" EXPORT_API void EXPORT_CC coreclr_unity_profiler_register(const CLSID
     g_profControlBlock.storedProfilers.InsertHead(profilerData);
 }
 
+extern "C" EXPORT_API ObjectHandleID EXPORT_CC coreclr_unity_profiler_get_managed_assembly_load_context(AssemblyID assemblyID)
+{
+    STATIC_CONTRACT_NOTHROW;
+
+    Assembly *pAssembly = (Assembly*)assemblyID;
+    if (pAssembly == NULL)
+        return NULL;
+
+    AssemblyBinder* pAssemblyBinder = pAssembly->GetPEAssembly()->GetAssemblyBinder();
+    if (pAssemblyBinder->IsDefault())
+        return NULL;
+
+    // ManagedAssemblyLoadContext is a handle to the managed AssemblyLoadContext object
+    return (ObjectHandleID)pAssemblyBinder->GetManagedAssemblyLoadContext();
+}
+
 extern "C" EXPORT_API gboolean EXPORT_CC coreclr_unity_gc_concurrent_mode(gboolean state)
 {
     CONTRACTL


### PR DESCRIPTION
Exposed coreclr_unity_profiler_get_managed_assembly_load_context API to get owning ALC for the AssemblyID

**Motivation**

It is not possible to obtain information about owning AssemblyLoadContext of native `Assembly`'s object.

Managed `Assembly` object does not have information about parent `AssemblyLoadContext` in managed data, as well as managed `AssemblyLoadContext` does not have data about own modules/assemblies in managed data. This information is stored only in native land as a part of `AssemblyBinder` ([m_ptrManagedAssemblyLoadContext](https://github.com/Unity-Technologies/runtime/blob/unity-main/src/coreclr/vm/assemblybinder.h#L128) member variable) and is stored when the managed `AssemblyLoadContext` instance is initialized in managed code.
At the same time [ICorProfilerInfo set of APIs](https://learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/icorprofilerinfo-interface) do not expose managed object handle for the `AssemblyID` object which we can get hold of when inspecting object (ObjectID->ClassID->ModuleID->AssemblyID).

In order to be able to attribute particular type to a particular managed `AssemblyLoadContext` we need to be able to retrieve ObjectHandleID of it from a native `AssemblyID` value.

**Changes**

Exposed `coreclr_unity_profiler_get_managed_assembly_load_context` which simply returns `m_ptrManagedAssemblyLoadContext` for a given `Assembly*` instance.