### PR TITLE
Add crash callback and stack frame info APIs

### DIFF
--- a/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
+++ b/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
@@ -73,3 +73,4 @@ EXPORTS
         mono_unity_g_free
         unity_coreclr_create_delegate
         coreclr_unity_gc_set_chain_fatal_error
+        coreclr_unity_set_on_fatal_error

--- a/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
+++ b/src/coreclr/dlls/mscoree/mscorwks_ntdef.src
@@ -74,3 +74,4 @@ EXPORTS
         unity_coreclr_create_delegate
         coreclr_unity_gc_set_chain_fatal_error
         coreclr_unity_set_on_fatal_error
+        coreclr_unity_get_stackframe_info_from_ip

--- a/src/coreclr/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/coreclr/dlls/mscoree/mscorwks_unixexports.src
@@ -61,3 +61,4 @@ mono_unity_g_free
 unity_coreclr_create_delegate
 coreclr_unity_gc_set_chain_fatal_error
 coreclr_unity_set_on_fatal_error
+coreclr_unity_get_stackframe_info_from_ip

--- a/src/coreclr/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/coreclr/dlls/mscoree/mscorwks_unixexports.src
@@ -60,3 +60,4 @@ mono_unity_class_has_failure
 mono_unity_g_free
 unity_coreclr_create_delegate
 coreclr_unity_gc_set_chain_fatal_error
+coreclr_unity_set_on_fatal_error

--- a/src/coreclr/vm/eepolicy.cpp
+++ b/src/coreclr/vm/eepolicy.cpp
@@ -750,6 +750,9 @@ int NOINLINE WrapperClrCaptureContext(CONTEXT* context)
 #pragma optimize("", on)
 #endif // defined(TARGET_X86) && defined(TARGET_WINDOWS)
 
+
+void (__cdecl *g_unityOnFatalError)(PEXCEPTION_POINTERS pExceptionPointers);
+
 // This method must return a value to avoid getting non-actionable dumps on x86.
 // If this method were a DECLSPEC_NORETURN then dumps would not provide the necessary
 // context at the point of the failure
@@ -792,6 +795,8 @@ int NOINLINE EEPolicy::HandleFatalError(UINT exitCode, UINT_PTR address, LPCWSTR
         // This is fatal error.  We do not care about SO mode any more.
         // All of the code from here on out is robust to any failures in any API's that are called.
         CONTRACT_VIOLATION(GCViolation | ModeViolation | FaultNotFatal | TakesLockViolation);
+        if (g_unityOnFatalError)
+            g_unityOnFatalError(&exceptionPointers);
 
 
         // Setting g_fFatalErrorOccurredOnGCThread allows code to avoid attempting to make GC mode transitions which could

--- a/src/coreclr/vm/mono/mono_coreclr.cpp
+++ b/src/coreclr/vm/mono/mono_coreclr.cpp
@@ -967,3 +967,11 @@ extern "C" EXPORT_API gboolean EXPORT_CC coreclr_unity_gc_set_chain_fatal_error(
     g_chainFatalError = (bool)state;
     return prev;
 }
+
+typedef void (__cdecl *OnFatalErrorFunc)(EXCEPTION_POINTERS* pExceptionPointers);
+extern OnFatalErrorFunc g_unityOnFatalError;
+
+extern "C" EXPORT_API void EXPORT_CC coreclr_unity_set_on_fatal_error(OnFatalErrorFunc on_fatal_func)
+{
+    g_unityOnFatalError = on_fatal_func;
+}


### PR DESCRIPTION
Add `coreclr_unity_set_on_fatal_error` to provide a callback for a fatal error on Windows before CoreCLR terminates the process.

Add `coreclr_unity_get_stackframe_info_from_ip` to extract stack frame info, e.g. method` from instruction pointer. This is used to resolve managed frame information when capturing callstacks.