### PR TITLE
Added --keep-native-symbols cmdline option

### DIFF
--- a/unity/CITools/BuildDriver/CoreCLR.cs
+++ b/unity/CITools/BuildDriver/CoreCLR.cs
@@ -22,7 +22,7 @@ public static class CoreCLR
         return subsets.AggregateWith("+");
     }
 
-    public static void Build(GlobalConfig gConfig, BuildTargets buildTargets)
+    public static void Build(GlobalConfig gConfig, BuildTargets buildTargets, bool keepNativeSymbols)
     {
         Console.WriteLine("******************************");
         Console.WriteLine("Unity: Building CoreCLR runtime");
@@ -49,7 +49,7 @@ public static class CoreCLR
             args.Add($"-ninja{crossbuild}");
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (keepNativeSymbols && RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
             // The default build uses `dsymutil --flat`, which generates .dwarf files that are
             // not automatically picked up by anything. Standard .dSYM are a pain to deal with.

--- a/unity/CITools/BuildDriver/Program.cs
+++ b/unity/CITools/BuildDriver/Program.cs
@@ -111,6 +111,18 @@ public class Program
             }
         });
 
+        var keepNativeSymbols = new Option<bool>("--keep-native-symbols")
+        {
+            DefaultValueFactory = (_) => false,
+            Description = "Do not strip binaries and keep native symbols",
+        };
+        keepNativeSymbols.Validators.Add(result =>
+        {
+            bool val = result.GetValue(keepNativeSymbols);
+            if (val && RunningOnYamato())
+                result.AddError($"Yamato builds must strip binaries and {keepNativeSymbols.Name} must not be used");
+        });
+
         RootCommand rootCommand = new RootCommand("Unity CoreCLR Builder")
         {
             buildOption,
@@ -119,7 +131,8 @@ public class Program
             configurationOption,
             verbosityOption,
             zipOption,
-            deployToPlayer
+            deployToPlayer,
+            keepNativeSymbols
         };
         rootCommand.SetAction(Run);
 
@@ -133,6 +146,7 @@ public class Program
             string? architecture = context.ParseResult.GetValue(architectureOption);
             string? configuration = context.ParseResult.GetValue(configurationOption);
             string? deployToProjectPath = context.ParseResult.GetValue(deployToPlayer);
+            bool keepSymbols = context.ParseResult.GetValue(keepNativeSymbols);
 
             if (bTargets == BuildTargets.None && tTargets == TestTargets.None && string.IsNullOrEmpty(deployToProjectPath))
                 bTargets = BuildTargets.All;
@@ -159,7 +173,7 @@ public class Program
             if (bTargets != BuildTargets.None)
             {
                 if (bTargets.HasFlag(BuildTargets.Runtime) || bTargets.HasFlag(BuildTargets.ClassLibs))
-                    CoreCLR.Build(gConfig, bTargets);
+                    CoreCLR.Build(gConfig, bTargets, keepSymbols);
 
                 // TODO: Switch to using Embedding Host build to perform the copy instead of this once that lands.
                 NPath artifacts = Artifacts.ConsolidateArtifacts(gConfig);

--- a/unity/CITools/BuildDriver/Program.cs
+++ b/unity/CITools/BuildDriver/Program.cs
@@ -113,7 +113,7 @@ public class Program
 
         var keepNativeSymbols = new Option<bool>("--keep-native-symbols")
         {
-            DefaultValueFactory = (_) => false,
+            DefaultValueFactory = (_) => !RunningOnYamato(),
             Description = "Do not strip binaries and keep native symbols",
         };
         keepNativeSymbols.Validators.Add(result =>


### PR DESCRIPTION
Using `CLR_CMAKE_KEEP_NATIVE_SYMBOLS=TRUE` prevents binaries from being signed as [signing is part of stripping](https://github.com/Unity-Technologies/runtime/blob/unity-main/eng/native/functions.cmake#L407) in cmake script

I suggest moving it under `--keep-native-symbols` cmdline option so that we use stripped and signed binaries for the Editor builds, but allow no stripping for local CoreCLR builds. And enable the option by default when not running on Yamato as per @UnityAlex advice.