### PR TITLE
Fixed SzArray from Collectible LoaderAllocator being allocated in frozen heap

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -51918,7 +51918,7 @@ void CFinalize::CheckFinalizerObjects()
 void gc_heap::walk_heap_per_heap (walk_fn fn, void* context, int gen_number, BOOL walk_large_object_heap_p)
 {
     generation* gen = gc_heap::generation_of (gen_number);
-    heap_segment*    seg = heap_segment_in_range (generation_start_segment (gen));
+    heap_segment*    seg = generation_start_segment (gen);
     uint8_t* x = ((gen_number == max_generation) ? heap_segment_mem (seg) : get_soh_start_object (seg, gen));
     uint8_t*       end = heap_segment_allocated (seg);
     int align_const = get_alignment_constant (TRUE);
@@ -51928,7 +51928,7 @@ void gc_heap::walk_heap_per_heap (walk_fn fn, void* context, int gen_number, BOO
     {
         if (x >= end)
         {
-            if ((seg = heap_segment_next_in_range (seg)) != 0)
+            if ((seg = heap_segment_next (seg)) != 0)
             {
                 x = heap_segment_mem (seg);
                 end = heap_segment_allocated (seg);
@@ -51940,7 +51940,7 @@ void gc_heap::walk_heap_per_heap (walk_fn fn, void* context, int gen_number, BOO
                 // advance to next lower generation
                 gen_number--;
                 gen = gc_heap::generation_of (gen_number);
-                seg = heap_segment_in_range (generation_start_segment (gen));
+                seg = generation_start_segment (gen);
 
                 x = heap_segment_mem (seg);
                 end = heap_segment_allocated (seg);
@@ -51952,12 +51952,12 @@ void gc_heap::walk_heap_per_heap (walk_fn fn, void* context, int gen_number, BOO
                 if (walk_large_object_heap_p)
                 {
                     walk_large_object_heap_p = FALSE;
-                    seg = heap_segment_in_range (generation_start_segment (large_object_generation));
+                    seg = generation_start_segment (large_object_generation);
                 }
                 else if (walk_pinned_object_heap)
                 {
                     walk_pinned_object_heap = FALSE;
-                    seg = heap_segment_in_range (generation_start_segment (pinned_object_generation));
+                    seg = generation_start_segment (pinned_object_generation);
                 }
                 else
                 {

--- a/src/coreclr/vm/frozenobjectheap.cpp
+++ b/src/coreclr/vm/frozenobjectheap.cpp
@@ -46,6 +46,7 @@ Object* FrozenObjectHeapManager::TryAllocateObject(PTR_MethodTable type, size_t 
             CrstHolder ch(&m_Crst);
 
             _ASSERT(type != nullptr);
+            _ASSERT(!type->Collectible());
             _ASSERT(FOH_COMMIT_SIZE >= MIN_OBJECT_SIZE);
 
             // Currently we don't support frozen objects with special alignment requirements

--- a/src/coreclr/vm/gchelpers.cpp
+++ b/src/coreclr/vm/gchelpers.cpp
@@ -510,9 +510,11 @@ OBJECTREF TryAllocateFrozenSzArray(MethodTable* pArrayMT, INT32 cElements)
 
     CorElementType elemType = pArrayMT->GetArrayElementType();
 
-    if (pArrayMT->ContainsPointers() && cElements > 0)
+    if (pArrayMT->Collectible() || (pArrayMT->ContainsPointers() && cElements > 0))
     {
-        // For arrays with GC pointers we can only work with empty arrays
+        // We cannot allocate in the frozen heap if:
+        // - the array type is collectible
+        // - or for non empty arrays with GC pointers
         return NULL;
     }
 

--- a/src/coreclr/vm/mono/mono_coreclr.cpp
+++ b/src/coreclr/vm/mono/mono_coreclr.cpp
@@ -983,7 +983,7 @@ extern "C" EXPORT_API bool EXPORT_CC coreclr_unity_get_stackframe_info_from_ip(v
 {
     CONTRACTL
     {
-        NOTHROW;
+        THROWS;
         GC_NOTRIGGER;
         MODE_ANY;
     }


### PR DESCRIPTION
Ensure we don't add Array instances of types in collectible LoaderAllocators to frozen heap.

Additionally:

- Undo temporary fix for diagnostic heap walk added in https://github.com/Unity-Technologies/runtime/pull/254
- Update method `coreclr_unity_get_stackframe_info_from_ip` THROWS to ensure it is aligned with inner method
