### PR TITLE
Fixed uninitialized EXCEPTION_POINTERS when passing information to Unity handler

### DIFF
--- a/src/coreclr/vm/eepolicy.cpp
+++ b/src/coreclr/vm/eepolicy.cpp
@@ -796,7 +796,7 @@ int NOINLINE EEPolicy::HandleFatalError(UINT exitCode, UINT_PTR address, LPCWSTR
         // All of the code from here on out is robust to any failures in any API's that are called.
         CONTRACT_VIOLATION(GCViolation | ModeViolation | FaultNotFatal | TakesLockViolation);
         if (g_unityOnFatalError)
-            g_unityOnFatalError(&exceptionPointers);
+            g_unityOnFatalError(pExceptionInfo);
 
 
         // Setting g_fFatalErrorOccurredOnGCThread allows code to avoid attempting to make GC mode transitions which could


### PR DESCRIPTION
When the `pExceptionInfo` is provided by the caller side we could pass uninitialized data to Unity crashhandler
The PR makes the full information to be propagated