### PR TITLE
Fix threadstatic cleanup

### DIFF
--- a/src/coreclr/vm/loaderallocator.cpp
+++ b/src/coreclr/vm/loaderallocator.cpp
@@ -964,12 +964,10 @@ void LoaderAllocator::SetHandleValue(LOADERHANDLE handle, OBJECTREF value)
     {
         NOTHROW;
         GC_NOTRIGGER;
-        MODE_ANY;
+        MODE_COOPERATIVE;
         PRECONDITION(handle != NULL);
     }
     CONTRACTL_END;
-
-    GCX_COOP();
 
     GCPROTECT_BEGIN(value);
 

--- a/src/coreclr/vm/threadstatics.cpp
+++ b/src/coreclr/vm/threadstatics.cpp
@@ -51,17 +51,14 @@ void ThreadLocalBlock::FreeTLM(SIZE_T i, BOOL isThreadShuttingdown)
                     {
                         ThreadLocalModule::CollectibleDynamicEntry *entry = (ThreadLocalModule::CollectibleDynamicEntry*)pThreadLocalModule->m_pDynamicClassTable[k].m_pDynamicEntry;
                         PTR_LoaderAllocator pLoaderAllocator = entry->m_pLoaderAllocator;
-                        // Skip assemblies that are already unloaded
-                        if (!pLoaderAllocator->IsUnloaded())
+
+                        if (entry->m_hGCStatics != NULL)
                         {
-                            if (entry->m_hGCStatics != NULL)
-                            {
-                                pLoaderAllocator->FreeHandle(entry->m_hGCStatics);
-                            }
-                            if (entry->m_hNonGCStatics != NULL)
-                            {
-                                pLoaderAllocator->FreeHandle(entry->m_hNonGCStatics);
-                            }
+                            pLoaderAllocator->FreeHandle(entry->m_hGCStatics);
+                        }
+                        if (entry->m_hNonGCStatics != NULL)
+                        {
+                            pLoaderAllocator->FreeHandle(entry->m_hNonGCStatics);
                         }
                     }
                     delete pThreadLocalModule->m_pDynamicClassTable[k].m_pDynamicEntry;


### PR DESCRIPTION
Ensure LoaderAllocator can't be collected while we clean handles on collectible LoaderAllocators

If the exposed object is alive (NULL check) we can safely free LoaderAllocator handles and while we are doing that LoaderAllocator won't be collected (due to holding onto COOP section) and thus finalized