### PR TITLE
Add a UnityAot MSBuild option for Mono's System.Private.CoreLib

### DIFF
--- a/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -351,4 +351,7 @@
       <FileWrites Include="@(EventingSourceFile)" />
     </ItemGroup>
   </Target>
+
+  <Import Project="$([MSBuild]::NormalizeDirectory('$(RepoRoot)'))\unity\unityaot-props\System.Private.CoreLib.props"  Condition="'$(UnityAot)' == 'true'" />
+
 </Project>

--- a/unity/unityaot-props/System.Private.CoreLib.props
+++ b/unity/unityaot-props/System.Private.CoreLib.props
@@ -1,0 +1,12 @@
+<Project>
+    <PropertyGroup>
+        <DefineConstants>$(DefineConstants);UNITY_AOT</DefineConstants>
+        <NativeAotSourcesRoot>$(CoreClrProjectRoot)\nativeaot</NativeAotSourcesRoot>
+        <NativeAotSourceCoreLib>$(NativeAotSourcesRoot)\System.Private.CoreLib\src</NativeAotSourceCoreLib>
+    </PropertyGroup>
+    <ItemGroup>
+        <Compile Remove="$(BclSourcesRoot)\System\Collections\Generic\ArraySortHelper.Mono.cs" />
+        <Compile Include="$(NativeAotSourceCoreLib)\System\Collections\Generic\ArraySortHelper.NativeAot.cs" />
+    </ItemGroup>
+</Project>
+


### PR DESCRIPTION
IL2CPP is currently using the Mono System.Private.CoreLib implementation, but it contains some AOT unfriendly code paths.  We instead want to be able to use the NativeAot version of ArraySortHelper.

This adds an UnityAot property that we can use to conditionally include files.  It also adds an UNITY_AOT compilation define that we can use.