### PR TITLE
Add define to allow explicit JNI initialization.

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -678,8 +678,13 @@ int GetEnumAsInt(JNIEnv *env, jobject enumObj)
     return value;
 }
 
+#ifdef PAL_JNI_EXPLICIT_ONLOAD
+JNIEXPORT jint JNICALL
+pal_JNI_OnLoad(JavaVM *vm, void *reserved)
+#else
 JNIEXPORT jint JNICALL
 JNI_OnLoad(JavaVM *vm, void *reserved)
+#endif
 {
     (void)reserved;
     LOG_INFO("JNI_OnLoad in pal_jni.c");


### PR DESCRIPTION
Enables native libraries to be statically linked in the presence of another library exporting a `JNI_OnLoad` API.