### PR TITLE
Rearrange artifacts in a way that makes a bit more sense for us on the Unity side.

### DIFF
--- a/unity/CITools/BuildDriver/Artifacts.cs
+++ b/unity/CITools/BuildDriver/Artifacts.cs
@@ -7,9 +7,22 @@ namespace BuildDriver;
 
 static class Artifacts
 {
+    // Clean up the artifacts dir and rearrange things into a structure that makes sense for us
     public static NPath ConsolidateArtifacts(GlobalConfig gConfig)
     {
         Paths.RepoRoot.Combine("LICENSE.TXT").Copy(Utils.RuntimeArtifactDirectory(gConfig).Combine("LICENSE.md"));
+
+        // This directory contains windows specific native libraries for reading/writing pdbs that we do not need.
+        Utils.RuntimeArtifactDirectory(gConfig).Combine("native", "runtimes").DeleteIfExists();
+
+        //Get rid of the tfm directory to save on code churn on our side when we upgrade. We won't be supporting more than one.
+        NPath lib = Utils.RuntimeArtifactDirectory(gConfig).Combine("lib");
+        NPath tfm = lib.Directories().First();
+        tfm.MoveFiles(lib, true);
+        tfm.Delete();
+
+        // Move System.Private.CoreLib from native to lib. This is where it lives when .Net is installed on a system
+        Utils.RuntimeArtifactDirectory(gConfig).Combine("native").MoveFiles(lib, false, path => path.FileName.StartsWith("System.Private.CoreLib"));
 
         return Utils.RuntimeArtifactDirectory(gConfig);
     }

--- a/unity/CITools/BuildDriver/Artifacts.cs
+++ b/unity/CITools/BuildDriver/Artifacts.cs
@@ -10,21 +10,27 @@ static class Artifacts
     // Clean up the artifacts dir and rearrange things into a structure that makes sense for us
     public static NPath ConsolidateArtifacts(GlobalConfig gConfig)
     {
-        Paths.RepoRoot.Combine("LICENSE.TXT").Copy(Utils.RuntimeArtifactDirectory(gConfig).Combine("LICENSE.md"));
+        // make our own artifacts directory to prevent tests from failing to run due to our moving things around.
+        NPath unityArtifacts = Utils.UnityRuntimeArtifactDirectory(gConfig);
+        unityArtifacts.DeleteIfExists();
+        unityArtifacts.CreateDirectory();
+        Utils.RuntimeArtifactDirectory(gConfig).CopyFiles(unityArtifacts, true);
+
+        Paths.RepoRoot.Combine("LICENSE.TXT").Copy(unityArtifacts.Combine("LICENSE.md"));
 
         // This directory contains windows specific native libraries for reading/writing pdbs that we do not need.
-        Utils.RuntimeArtifactDirectory(gConfig).Combine("native", "runtimes").DeleteIfExists();
+        unityArtifacts.Combine("native", "runtimes").DeleteIfExists();
 
         //Get rid of the tfm directory to save on code churn on our side when we upgrade. We won't be supporting more than one.
-        NPath lib = Utils.RuntimeArtifactDirectory(gConfig).Combine("lib");
+        NPath lib = unityArtifacts.Combine("lib");
         NPath tfm = lib.Directories().First();
         tfm.MoveFiles(lib, true);
         tfm.Delete();
 
         // Move System.Private.CoreLib from native to lib. This is where it lives when .Net is installed on a system
-        Utils.RuntimeArtifactDirectory(gConfig).Combine("native").MoveFiles(lib, false, path => path.FileName.StartsWith("System.Private.CoreLib"));
+        unityArtifacts.Combine("native").MoveFiles(lib, false, path => path.FileName.StartsWith("System.Private.CoreLib"));
 
-        return Utils.RuntimeArtifactDirectory(gConfig);
+        return unityArtifacts;
     }
 
 }

--- a/unity/CITools/BuildDriver/Program.cs
+++ b/unity/CITools/BuildDriver/Program.cs
@@ -176,19 +176,21 @@ public class Program
                     CoreCLR.Build(gConfig, bTargets, keepSymbols);
 
                 // TODO: Switch to using Embedding Host build to perform the copy instead of this once that lands.
-                NPath artifacts = Artifacts.ConsolidateArtifacts(gConfig);
-
-                NPath zipExe = new("7z");
-                if (zipTask != null)
-                {
-                    zipTask.Wait();
-                    zipExe = zipTask.Result;
-                    if (zipTask.Exception != null)
-                        throw zipTask.Exception;
-                }
-
                 if (context.ParseResult.GetValue(zipOption))
+                {
+                    NPath artifacts = Artifacts.ConsolidateArtifacts(gConfig);
+
+                    NPath zipExe = new("7z");
+                    if (zipTask != null)
+                    {
+                        zipTask.Wait();
+                        zipExe = zipTask.Result;
+                        if (zipTask.Exception != null)
+                            throw zipTask.Exception;
+                    }
+                
                     SevenZip.Zip(zipExe, artifacts, gConfig);
+                }
             }
 
             if (tTargets != TestTargets.None)

--- a/unity/CITools/BuildDriver/Utils.cs
+++ b/unity/CITools/BuildDriver/Utils.cs
@@ -16,6 +16,12 @@ public class Utils
             $"microsoft.netcore.app.runtime.{Paths.ShortPlatformNameInPaths}-{gConfig.Architecture}", gConfig.Configuration, "runtimes",
             $"{Paths.ShortPlatformNameInPaths}-{gConfig.Architecture}");
 
+    public static NPath UnityRuntimeArtifactDirectory(GlobalConfig gConfig)
+        => Paths.RepoRoot.Combine("artifacts", "unity-bin",
+            $"microsoft.netcore.app.runtime.{Paths.ShortPlatformNameInPaths}-{gConfig.Architecture}", gConfig.Configuration, "runtimes",
+            $"{Paths.ShortPlatformNameInPaths}-{gConfig.Architecture}");
+
+
     public static NPath UnityTestHostDotNetRoot(GlobalConfig gConfig)
         // Find the directory "net7.0-windows-Release-x64" without hard coding the tfm
         => Paths.RepoRoot.Combine("artifacts/bin/testhost")


### PR DESCRIPTION
Changes:

* Drop Microsoft native pdb reading libs from zip
* Move System.Private.CoreLib to lib directory from native